### PR TITLE
Disable using invoke dynamic in Groovy

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -55,7 +55,7 @@ repositories {
 
 dependencies {  
     compile "org.springframework:spring-web:$springVersion"
-    compile "org.codehaus.groovy:groovy-all:$groovyVersion:indy"
+    compile "org.codehaus.groovy:groovy-all:$groovyVersion"
     compile 'com.fasterxml.jackson.core:jackson-databind:2.4.1.3'
     compile "org.springframework.boot:spring-boot-starter-web:$springBootVersion"
     compile "org.codehaus.jackson:jackson-mapper-asl:$jacksonMapper"
@@ -75,10 +75,6 @@ dependencies {
     testCompile 'org.hamcrest:hamcrest-library:1.3'
     testCompile 'org.hibernate:hibernate-validator:5.1.2.Final'
     testCompile 'com.jayway.jsonpath:json-path-assert:0.9.1'
-}
-
-tasks.withType(GroovyCompile) {
-    groovyOptions.optimizationOptions.indy = true
 }
 
 task wrapper(type: Wrapper) {


### PR DESCRIPTION
This is a library and should be compatible also with projects which
do not use indy. In addition indy support in Gradle projects is
currently broken in Idea 14 EAP:
http://youtrack.jetbrains.com/issue/IDEA-126878
