### PR TITLE
Fix #98: Keep compile dependencies scope also in pom.xml

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -85,6 +85,18 @@ configure(srcSubprojects) {
                 from components.java
                 artifact sourcesJar
                 artifact javadocJar
+
+                //#89 - workaround to not to have only runtime dependencies in generated pom.xml
+                //Known limitation in maven-publish -  - http://forums.gradle.org/gradle/topics/maven_publish_plugin_generated_pom_making_dependency_scope_runtime#reply_14120711
+                pom.withXml {
+                    asNode().dependencies.'*'.findAll() {
+                        it.scope.text() == 'runtime' && project.configurations.compile.allDependencies.find { dep ->
+                            dep.name == it.artifactId.text()
+                        }
+                    }.each() {
+                        it.scope*.value = 'compile'
+                    }
+                }
             }
         }
     }


### PR DESCRIPTION
Due to a maven-publish plugin limitations all dependencies are set to runtime.
