### PR TITLE
[#70] More comprehensive dependency management - PoC

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,6 +8,7 @@ buildscript {
         classpath 'com.ofg:uptodate-gradle-plugin:+'
         classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:+'
         classpath 'pl.allegro.tech.build:axion-release-plugin:0.9.4'
+        classpath "io.spring.gradle:dependency-management-plugin:0.2.1.RELEASE"
         if (project.hasProperty("coverage")) { classpath 'org.kt3k.gradle.plugin:coveralls-gradle-plugin:+' }
     }
 }
@@ -31,15 +32,6 @@ allprojects {
     }
 }
 
-ext {
-    microDepsSpringConfigVersion = '0.5.0'
-    groovyVersion = '2.3.7'
-    spockVersion = '0.7-groovy-2.0'
-    springBootVersion = '1.1.8.RELEASE'
-    springTestVersion = '4.1.1.RELEASE'
-    logbackVersion = '1.1.2'
-}
-
 task addHashFile << {
     String gitCmd = "git log --pretty=format:'%H' -n 1"
     def proc = gitCmd.execute()
@@ -54,8 +46,27 @@ configure(srcSubprojects) {
     apply plugin: 'maven-publish'
     apply plugin: 'com.jfrog.bintray'
     apply plugin: 'com.ofg.uptodate'
+    apply plugin: "io.spring.dependency-management"
 
     sourceCompatibility = 1.7
+
+    dependencyManagement {
+        dependencies {
+            dependencySet(group: "com.ofg", version: "0.5.0") {
+                entry "micro-deps-spring-config"
+                entry "micro-deps-spring-test-config"
+            }
+            "org.codehaus.groovy:groovy-all" "2.3.7"
+            "org.springframework.boot:spring-boot-starter-web" "1.1.8.RELEASE"
+            "ch.qos.logback:logback-classic" "1.1.2"
+
+            dependencySet(group:'org.spockframework', version: '0.7-groovy-2.0') {
+                entry "spock-core"
+                entry "spock-spring"
+            }
+            "org.springframework:spring-test" "4.1.1.RELEASE"
+        }
+    }
 
     //Workaround for the issue with Java 8u11 and 7u65 - http://www.infoq.com/news/2014/08/Java8-U11-Broke-Tools
     test {
@@ -95,6 +106,17 @@ configure(srcSubprojects) {
                         }
                     }.each() {
                         it.scope*.value = 'compile'
+                    }
+                    //#70 - workaround for empty version in pom.xml when dependency-management-plugin is used
+                    //Known limitation of new Gradle publishing mechanism - https://github.com/spring-gradle-plugins/dependency-management-plugin/issues/8
+                    asNode().dependencies[0]?.get('dependency')?.each() { dep ->
+                        String pomVer = dep.get("version").text();
+                        String pomArtifactId = dep.get("artifactId").text();
+                        String pomGroupId = dep.get("groupId").text();
+                        if (pomVer.isEmpty()) {
+                            def depVer = project.dependencyManagement.getManagedVersion("$pomGroupId", "$pomArtifactId")
+                            dep.appendNode('version', depVer)
+                        }
                     }
                 }
             }

--- a/micro-infra-camel/build.gradle
+++ b/micro-infra-camel/build.gradle
@@ -6,12 +6,12 @@ ext {
 
 dependencies {
     compile project(':micro-infra-spring-base')
-    compile "org.codehaus.groovy:groovy-all:$groovyVersion"
+    compile "org.codehaus.groovy:groovy-all"
     compile("org.apache.camel:camel-spring-javaconfig:$camelVersion") {
         exclude group: 'org.springframework', module: 'spring-test'
     }
-    testCompile "org.spockframework:spock-core:$spockVersion"
-    testRuntime "org.spockframework:spock-spring:$spockVersion"
+    testCompile "org.spockframework:spock-core"
+    testRuntime "org.spockframework:spock-spring"
     testCompile "org.apache.camel:camel-test-spring:$camelVersion"
-    testCompile "org.springframework:spring-test:$springTestVersion"
+    testCompile "org.springframework:spring-test"
 }

--- a/micro-infra-hystrix/build.gradle
+++ b/micro-infra-hystrix/build.gradle
@@ -2,10 +2,10 @@ description = 'Wrapper around HystrixCommand that propagates correlation ID'
 
 dependencies {
     compile project(':micro-infra-spring-base')
-    compile "org.codehaus.groovy:groovy-all:$groovyVersion"
+    compile "org.codehaus.groovy:groovy-all"
     compile 'com.netflix.hystrix:hystrix-core:1.4.0-RC5'
 
-    testCompile "org.spockframework:spock-core:$spockVersion"
-    testRuntime "org.spockframework:spock-spring:$spockVersion"
-    testCompile "org.springframework:spring-test:$springTestVersion"
+    testCompile "org.spockframework:spock-core"
+    testRuntime "org.spockframework:spock-spring"
+    testCompile "org.springframework:spring-test"
 }

--- a/micro-infra-spring-base/build.gradle
+++ b/micro-infra-spring-base/build.gradle
@@ -10,13 +10,13 @@ sourceSets.main.java.srcDirs = []
 sourceSets.main.groovy.srcDirs += ["src/main/java", "src/main/groovy"]
 
 dependencies {
-    compile("com.ofg:micro-deps-spring-config:$microDepsSpringConfigVersion") {
+    compile("com.ofg:micro-deps-spring-config") {
         //Required with micro-deps 0.4.0 as it uses groovy-all-indy which confuses Intellij Idea (both jars are added to dependencies)
         exclude group: 'org.codehaus.groovy', module: 'groovy-all'
     }
-    compile "org.codehaus.groovy:groovy-all:$groovyVersion"
+    compile "org.codehaus.groovy:groovy-all"
     compile 'com.fasterxml.jackson.core:jackson-databind:2.4.3'
-    compile "org.springframework.boot:spring-boot-starter-web:$springBootVersion"
+    compile "org.springframework.boot:spring-boot-starter-web"
     compile "org.codehaus.jackson:jackson-mapper-asl:$jacksonMapper"
     compile "org.codehaus.jackson:jackson-core-asl:$jacksonMapper"
     compile "org.aspectj:aspectjrt:$aspectjVersion"
@@ -25,9 +25,9 @@ dependencies {
 
     runtime "org.aspectj:aspectjweaver:$aspectjVersion"
 
-    testCompile "org.spockframework:spock-core:$spockVersion"
-    testRuntime "org.spockframework:spock-spring:$spockVersion"
-    testCompile "org.springframework:spring-test:$springTestVersion"
+    testCompile "org.spockframework:spock-core"
+    testRuntime "org.spockframework:spock-spring"
+    testCompile "org.springframework:spring-test"
     testCompile 'org.hamcrest:hamcrest-library:1.3'
     testCompile 'org.hibernate:hibernate-validator:5.1.3.Final'
     testCompile 'com.jayway.jsonpath:json-path-assert:0.9.1'

--- a/micro-infra-spring-config/build.gradle
+++ b/micro-infra-spring-config/build.gradle
@@ -20,13 +20,13 @@ dependencies {
     }
     compile "org.springframework.security:spring-security-rsa:$springSecurityRsaVersion"
     compile "org.eclipse.jgit:org.eclipse.jgit:2.3.1.201302201838-r"
-    compile "org.codehaus.groovy:groovy-all:$groovyVersion"
+    compile "org.codehaus.groovy:groovy-all"
     compile "org.aspectj:aspectjrt:1.8.3"
 
     testCompile "org.spockframework:spock-core:$spock10Version"
-    testRuntime "org.springframework:spring-test:$springTestVersion"
+    testRuntime "org.springframework:spring-test"
     testRuntime "org.spockframework:spock-spring:$spock10Version"
-    testRuntime "ch.qos.logback:logback-classic:$logbackVersion"
+    testRuntime "ch.qos.logback:logback-classic"
     testCompile 'com.jayway.awaitility:awaitility:1.6.2'
 }
 

--- a/micro-infra-spring-reactor/build.gradle
+++ b/micro-infra-spring-reactor/build.gradle
@@ -5,12 +5,12 @@ dependencies {
     compile "org.projectreactor:reactor-core:1.1.5.RELEASE"
     compile "org.projectreactor:reactor-spring:1.0.1.RELEASE"
 
-    testCompile("org.spockframework:spock-core:$spockVersion") {
+    testCompile("org.spockframework:spock-core") {
         exclude group: 'org.codehaus.groovy', module: 'groovy-all'
     }
-    testRuntime("org.spockframework:spock-spring:$spockVersion") {
+    testRuntime("org.spockframework:spock-spring") {
         exclude group: 'org.spockframework', module: 'spock-core'
     }
-    testCompile "org.springframework:spring-test:$springTestVersion"
+    testCompile "org.springframework:spring-test"
     testCompile 'com.jayway.awaitility:awaitility:1.6.2'
 }

--- a/micro-infra-spring-test/build.gradle
+++ b/micro-infra-spring-test/build.gradle
@@ -1,7 +1,7 @@
 description = 'Microservice testing utilities'
 
 dependencies {
-    compile("com.ofg:micro-deps-spring-test-config:$microDepsSpringConfigVersion") {
+    compile("com.ofg:micro-deps-spring-test-config") {
         //Required with micro-deps 0.4.0 as it uses groovy-all-indy which confuses Intellij Idea (both jars are added to dependencies)
         exclude group: 'org.codehaus.groovy', module: 'groovy-all'
     }

--- a/swagger/micro-infra-spring-swagger/build.gradle
+++ b/swagger/micro-infra-spring-swagger/build.gradle
@@ -1,10 +1,10 @@
 description = 'Microservice Spring Swagger configuration'
 
 dependencies {
-    compile "org.codehaus.groovy:groovy-all:$groovyVersion"
+    compile "org.codehaus.groovy:groovy-all"
     compile("com.mangofactory:swagger-springmvc:0.9.0") {
         exclude group: 'org.mockito'
         exclude module: 'scala-compiler'
     }
-    compile "org.springframework.boot:spring-boot-starter-web:$springBootVersion"
+    compile "org.springframework.boot:spring-boot-starter-web"
 }


### PR DESCRIPTION
With [dependency-management-plugin](https://github.com/spring-gradle-plugins/dependency-management-plugin) from Spring. The mechanism in old good Maven style ;).

In addition the it has an ability to [import Maven bom](https://github.com/spring-gradle-plugins/dependency-management-plugin#importing-a-maven-bom) (currently not used, but useful when using the whole stack from Spring.io).

WDYF? Is it more readable for you?
