### PR TITLE
[#116] Detection of using Java 8+ API

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ before_script:
  - "export JAVA_OPTS=-Xmx512m"
 
 script:
-- ./gradlew check --info --stacktrace --continue -Pcoverage
+- ./gradlew check --info --stacktrace --continue -Pcoverage -Pcompatibility
 
 env:
 - TERM=dumb

--- a/build.gradle
+++ b/build.gradle
@@ -9,6 +9,7 @@ buildscript {
         classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:+'
         classpath 'pl.allegro.tech.build:axion-release-plugin:0.9.4'
         if (project.hasProperty("coverage")) { classpath 'org.kt3k.gradle.plugin:coveralls-gradle-plugin:+' }
+        if (project.hasProperty("compatibility")) { classpath "be.insaneprogramming.gradle:animalsniffer-gradle-plugin:+" }
     }
 }
 
@@ -60,6 +61,18 @@ configure(srcSubprojects) {
     //Workaround for the issue with Java 8u11 and 7u65 - http://www.infoq.com/news/2014/08/Java8-U11-Broke-Tools
     test {
         jvmArgs '-noverify'
+    }
+
+    if (project.hasProperty("compatibility")) {
+        apply plugin: 'be.insaneprogramming.gradle.animalsniffer'
+
+        animalsniffer {
+            signature = "org.codehaus.mojo.signature:java17:+@signature"
+        }
+
+        afterEvaluate {
+            animalSniffer.mustRunAfter 'compileGroovy'
+        }
     }
 
     bintrayUpload.dependsOn 'build'


### PR DESCRIPTION
With https://bitbucket.org/lievendoclo/animalsniffer-gradle-plugin/

Fixes #116

There is a issue with that plugin (a task is created in afterEvaluate closure) which makes it harder to override configuration from command line. I will work on the upstream later to resolve that and simplify our configuration.
