### PR TITLE
addResourceLocations() takes paths, not patterns as per JavaDoc

### DIFF
--- a/swagger/micro-infra-spring-swagger/src/main/groovy/com/ofg/infrastructure/web/swagger/SwaggerConfiguration.groovy
+++ b/swagger/micro-infra-spring-swagger/src/main/groovy/com/ofg/infrastructure/web/swagger/SwaggerConfiguration.groovy
@@ -53,7 +53,7 @@ class SwaggerConfiguration extends WebMvcConfigurerAdapter {
     @Override
     public void addResourceHandlers(ResourceHandlerRegistry registry) {
         registry.addResourceHandler('/swagger/**', '/*.js', '/images/**', '/lib/**', '/css/**')
-                .addResourceLocations('classpath:/static/swagger/**', 'classpath:/static/swagger/images/**',
-                                       'classpath:/static/swagger/lib/**', 'classpath:/static/swagger/css/**')
+                .addResourceLocations('classpath:/static/swagger', 'classpath:/static/swagger/images',
+                                       'classpath:/static/swagger/lib', 'classpath:/static/swagger/css')
     }
 }


### PR DESCRIPTION
Apparently this bug surfaced only after upgrade from Spring Boot 1.1.8 to 1.1.9
Fixes #157