### PR TITLE
PropertySourcesPlaceholderConfigurer bean added to context defined in MockServerConfiguration

### DIFF
--- a/micro-deps/micro-deps-spring-test-config/src/main/groovy/com/ofg/infrastructure/discovery/web/MockServerConfiguration.groovy
+++ b/micro-deps/micro-deps-spring-test-config/src/main/groovy/com/ofg/infrastructure/discovery/web/MockServerConfiguration.groovy
@@ -3,6 +3,7 @@ import groovy.transform.CompileStatic
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
+import org.springframework.context.support.PropertySourcesPlaceholderConfigurer
 
 /**
  * Configuration that registers {@link HttpMockServer} as a Spring bean. Takes care
@@ -13,6 +14,11 @@ import org.springframework.context.annotation.Configuration
 @CompileStatic
 @Configuration
 class MockServerConfiguration {
+
+    @Bean
+    PropertySourcesPlaceholderConfigurer propertySourcesPlaceholderConfigurer() {
+        return new PropertySourcesPlaceholderConfigurer();
+    }
 
     @Bean(initMethod = 'start', destroyMethod = 'shutdownServer')
     HttpMockServer httpMockServer(@Value('${wiremock.port:8030}') Integer wiremockPort) {


### PR DESCRIPTION
In order to be able write integration tests, that directly extends MvcWiremockIntegrationTest I have added an instance of PropertySourcesPlaceholderConfigurer bean to the context initiated by this tests. It enables Spring to evaluate SPEL in MockServerConfiguration.httpMockServer method.