### PR TITLE
Alternative way to customize ServiceRestClient beans (PoC)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -139,6 +139,9 @@ configure(srcSubprojects) {
         jvmArgs project.gradle.startParameter.systemPropertiesArgs.entrySet().collect{"-D${it.key}=${it.value}"}
         //Workaround for the issue with Java 8u11 and 7u65 - http://www.infoq.com/news/2014/08/Java8-U11-Broke-Tools
         jvmArgs '-noverify'
+        testLogging {
+            exceptionFormat = 'full'
+        }
     }
 
     if (project.hasProperty("compatibility")) {

--- a/micro-infra-spring-base/src/main/groovy/com/ofg/infrastructure/web/resttemplate/fluent/ServiceRestClientConfiguration.groovy
+++ b/micro-infra-spring-base/src/main/groovy/com/ofg/infrastructure/web/resttemplate/fluent/ServiceRestClientConfiguration.groovy
@@ -9,6 +9,7 @@ import com.ofg.infrastructure.discovery.ServiceResolver
 import com.ofg.infrastructure.metrics.config.EnableMetrics
 import com.ofg.infrastructure.web.resttemplate.MetricsAspect
 import com.ofg.infrastructure.web.resttemplate.custom.RestTemplate
+import com.ofg.infrastructure.web.resttemplate.fluent.config.ServiceRestClientConfigurer
 import groovy.transform.CompileStatic
 import org.springframework.beans.BeansException
 import org.springframework.beans.factory.annotation.Autowired
@@ -44,6 +45,9 @@ class ServiceRestClientConfiguration {
     @Value('${rest.client.maxLogResponseChars:4096}') int maxLogResponseChars
     @Value('${retry.threads:10}') int retryPoolThreads
 
+    @Autowired(required = false)
+    private ServiceRestClientConfigurer serviceRestClientConfigurer
+
     @Bean
     ServiceRestClient serviceRestClient(ServiceResolver serviceResolver, ServiceConfigurationResolver configurationResolver) {
         return new ServiceRestClient(microInfraSpringRestTemplate(), serviceResolver, configurationResolver)
@@ -51,6 +55,14 @@ class ServiceRestClientConfiguration {
 
     @Bean
     RestOperations microInfraSpringRestTemplate() {
+        if (serviceRestClientConfigurer?.restTemplate) {
+            return serviceRestClientConfigurer.restTemplate
+        } else {
+            return createDefaultRestTemplate()
+        }
+    }
+
+    private RestTemplate createDefaultRestTemplate() {
         RestTemplate restTemplate = new RestTemplate(maxLogResponseChars)
         restTemplate.requestFactory = requestFactory()
         return restTemplate

--- a/micro-infra-spring-base/src/main/groovy/com/ofg/infrastructure/web/resttemplate/fluent/ServiceRestClientConfiguration.groovy
+++ b/micro-infra-spring-base/src/main/groovy/com/ofg/infrastructure/web/resttemplate/fluent/ServiceRestClientConfiguration.groovy
@@ -55,11 +55,7 @@ class ServiceRestClientConfiguration {
 
     @Bean
     RestOperations microInfraSpringRestTemplate() {
-        if (serviceRestClientConfigurer?.restTemplate) {
-            return serviceRestClientConfigurer.restTemplate
-        } else {
-            return createDefaultRestTemplate()
-        }
+        return serviceRestClientConfigurer?.restTemplate ?: createDefaultRestTemplate()
     }
 
     private RestTemplate createDefaultRestTemplate() {

--- a/micro-infra-spring-base/src/main/groovy/com/ofg/infrastructure/web/resttemplate/fluent/config/ServiceRestClientConfigurer.groovy
+++ b/micro-infra-spring-base/src/main/groovy/com/ofg/infrastructure/web/resttemplate/fluent/config/ServiceRestClientConfigurer.groovy
@@ -1,0 +1,22 @@
+package com.ofg.infrastructure.web.resttemplate.fluent.config
+
+import org.springframework.web.client.RestOperations
+
+/**
+ * Interface to be implemented by Spring beans willing to provide their own components for
+ * {@link com.ofg.infrastructure.web.resttemplate.fluent.ServiceRestClientConfiguration ServiceRestClientConfiguration}.
+ *
+ * <p>Consider using {@link com.ofg.infrastructure.web.resttemplate.fluent.config.ServiceRestClientConfigurerSupport ServiceRestClientConfigurerSupport}
+ * providing default implementations for all components. Only custom components needs to be overridden. Furthermore, backward compatibility
+ * of this interface will be insured in case new customization options are introduced in the future.
+ *
+ * <p>See {@link com.ofg.infrastructure.web.resttemplate.fluent.ServiceRestClientConfiguration ServiceRestClientConfiguration}.
+ *
+ * @since 0.8.3
+ */
+interface ServiceRestClientConfigurer {
+
+    RestOperations getRestTemplate()
+
+    //Other important beans...
+}

--- a/micro-infra-spring-base/src/main/groovy/com/ofg/infrastructure/web/resttemplate/fluent/config/ServiceRestClientConfigurerSupport.groovy
+++ b/micro-infra-spring-base/src/main/groovy/com/ofg/infrastructure/web/resttemplate/fluent/config/ServiceRestClientConfigurerSupport.groovy
@@ -1,0 +1,18 @@
+package com.ofg.infrastructure.web.resttemplate.fluent.config
+
+import org.springframework.web.client.RestOperations
+
+/**
+ * A convenience {@link com.ofg.infrastructure.web.resttemplate.fluent.config.ServiceRestClientConfigurer ServiceRestClientConfigurer} that
+ * implements all methods so that the defaults are used. Provides a backward compatible alternative of implementing
+ * {@link com.ofg.infrastructure.web.resttemplate.fluent.config.ServiceRestClientConfigurer ServiceRestClientConfigurer}.
+ *
+ * @since 0.8.3
+ */
+class ServiceRestClientConfigurerSupport implements ServiceRestClientConfigurer {
+
+    @Override
+    RestOperations getRestTemplate() {
+        return null
+    }
+}

--- a/micro-infra-spring-base/src/test/groovy/com/ofg/infrastructure/web/resttemplate/fluent/ServiceRestClientCustomizationByNameSpec.groovy
+++ b/micro-infra-spring-base/src/test/groovy/com/ofg/infrastructure/web/resttemplate/fluent/ServiceRestClientCustomizationByNameSpec.groovy
@@ -1,0 +1,50 @@
+package com.ofg.infrastructure.web.resttemplate.fluent
+
+import com.codahale.metrics.MetricRegistry
+import com.ofg.infrastructure.base.BaseConfiguration
+import com.ofg.infrastructure.base.MvcCorrelationIdSettingIntegrationSpec
+import com.ofg.infrastructure.web.resttemplate.MetricsAspect
+import groovy.transform.CompileStatic
+import groovy.transform.InheritConstructors
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.SpringApplicationContextLoader
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.context.annotation.EnableAspectJAutoProxy
+import org.springframework.context.annotation.Import
+import org.springframework.test.context.ContextConfiguration
+
+@ContextConfiguration(classes = CustomConfig, loader = SpringApplicationContextLoader)
+class ServiceRestClientCustomizationByNameSpec extends MvcCorrelationIdSettingIntegrationSpec {
+
+    @Autowired
+    private MetricsAspect metricsAspect2
+
+    def "should allow to autowire by name and more than one bean available"() {
+        expect:
+            metricsAspect2 instanceof TestMetricsAspect2
+    }
+
+    @Configuration
+    @Import(BaseConfiguration)
+    @EnableServiceRestClient
+    @CompileStatic
+    @EnableAspectJAutoProxy(proxyTargetClass = true)
+    static class CustomConfig {
+        @Bean
+        MetricsAspect metricsAspect2(MetricRegistry metricRegistry) {
+            return new TestMetricsAspect2(metricRegistry)
+        }
+
+        @Bean
+        MetricsAspect metricsAspect3(MetricRegistry metricRegistry) {
+            return new TestMetricsAspect3(metricRegistry)
+        }
+    }
+
+    @InheritConstructors
+    static class TestMetricsAspect2 extends MetricsAspect {}
+
+    @InheritConstructors
+    static class TestMetricsAspect3 extends MetricsAspect {}
+}

--- a/micro-infra-spring-base/src/test/groovy/com/ofg/infrastructure/web/resttemplate/fluent/ServiceRestClientCustomizationSpec.groovy
+++ b/micro-infra-spring-base/src/test/groovy/com/ofg/infrastructure/web/resttemplate/fluent/ServiceRestClientCustomizationSpec.groovy
@@ -1,7 +1,7 @@
 package com.ofg.infrastructure.web.resttemplate.fluent
 
 import com.ofg.infrastructure.base.BaseConfiguration
-import com.ofg.infrastructure.web.resttemplate.fluent.common.response.executor.RestExecutor
+import com.ofg.infrastructure.base.MvcCorrelationIdSettingIntegrationSpec
 import com.ofg.infrastructure.web.resttemplate.fluent.config.ServiceRestClientConfigurer
 import com.ofg.infrastructure.web.resttemplate.fluent.config.ServiceRestClientConfigurerSupport
 import groovy.transform.CompileStatic
@@ -13,10 +13,9 @@ import org.springframework.context.annotation.EnableAspectJAutoProxy
 import org.springframework.context.annotation.Import
 import org.springframework.test.context.ContextConfiguration
 import org.springframework.web.client.RestOperations
-import spock.lang.Specification
 
 @ContextConfiguration(classes = CustomConfig, loader = SpringApplicationContextLoader)
-class ServiceRestClientCustomizationSpec extends Specification {
+class ServiceRestClientCustomizationSpec extends MvcCorrelationIdSettingIntegrationSpec {
 
     @Autowired
     private ServiceRestClient serviceRestClient

--- a/micro-infra-spring-base/src/test/groovy/com/ofg/infrastructure/web/resttemplate/fluent/ServiceRestClientCustomizationSpec.groovy
+++ b/micro-infra-spring-base/src/test/groovy/com/ofg/infrastructure/web/resttemplate/fluent/ServiceRestClientCustomizationSpec.groovy
@@ -1,0 +1,45 @@
+package com.ofg.infrastructure.web.resttemplate.fluent
+
+import com.ofg.infrastructure.base.BaseConfiguration
+import com.ofg.infrastructure.web.resttemplate.fluent.common.response.executor.RestExecutor
+import com.ofg.infrastructure.web.resttemplate.fluent.config.ServiceRestClientConfigurer
+import com.ofg.infrastructure.web.resttemplate.fluent.config.ServiceRestClientConfigurerSupport
+import groovy.transform.CompileStatic
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.SpringApplicationContextLoader
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.context.annotation.EnableAspectJAutoProxy
+import org.springframework.context.annotation.Import
+import org.springframework.test.context.ContextConfiguration
+import org.springframework.web.client.RestOperations
+import spock.lang.Specification
+
+@ContextConfiguration(classes = CustomConfig, loader = SpringApplicationContextLoader)
+class ServiceRestClientCustomizationSpec extends Specification {
+
+    @Autowired
+    private ServiceRestClient serviceRestClient
+
+    def "should allow to provide custom RestTemplate via ServiceRestClientConfigurer"() {
+        expect:
+            serviceRestClient.restOperations instanceof TestRestTemplate
+    }
+
+    @Configuration
+    @Import(BaseConfiguration)
+    @EnableServiceRestClient
+    @CompileStatic
+    @EnableAspectJAutoProxy(proxyTargetClass = true)
+    static class CustomConfig {
+        @Bean
+        ServiceRestClientConfigurer serviceRestClientConfigurer() {
+            new ServiceRestClientConfigurerSupport() {
+                @Override
+                RestOperations getRestTemplate() {
+                    return new TestRestTemplate()
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
**DO NOT MERGE** - this is a PoC to discuss.

In reference to issues with custom `RestTemplate` or its modification I took a look how Spring manages beans customization on their own (with `@EnableAsync` and `@EnableScheduling`). One of the possible solution is to provide an additional optional bean which when available will provide beans which should be used by `ServiceRestClientConfigurer`. By default beans with default values will be created.

Cons. The solution does not allow to modify existing default components. It complicates Configuration code.

CC: @mariuszs, @ArturGajowy 