### PR TITLE
Un-ignoring tests, working after upgrade to Spring Cloud M3

### DIFF
--- a/micro-infra-spring-config/src/test/groovy/com/ofg/infrastructure/property/decrypt/DecryptingPropertyExtendedTest.groovy
+++ b/micro-infra-spring-config/src/test/groovy/com/ofg/infrastructure/property/decrypt/DecryptingPropertyExtendedTest.groovy
@@ -3,13 +3,9 @@ package com.ofg.infrastructure.property.decrypt
 import com.ofg.infrastructure.property.AbstractIntegrationTest
 import org.codehaus.groovy.runtime.StackTraceUtils
 import org.springframework.boot.builder.SpringApplicationBuilder
-import spock.lang.Ignore
-import spock.lang.Issue
 
 class DecryptingPropertyExtendedTest extends AbstractIntegrationTest {
 
-    @Ignore("Broken with spring-cloud 1.0.0.M2 - enable when M3 is available")
-    @Issue("https://github.com/4finance/micro-infra-spring/issues/97")
     def "should fail when wrong encryption key is provided and there are encrypted passwords"() {
         given:
             System.setProperty("encrypt.key", "wrongKey")
@@ -24,8 +20,6 @@ class DecryptingPropertyExtendedTest extends AbstractIntegrationTest {
             context?.close()
     }
 
-    @Ignore("Broken with spring-cloud 1.0.0.M2 - enable when M3 is available")
-    @Issue("https://github.com/4finance/micro-infra-spring/issues/97")
     def "should fail when encryption key is not provided and there are encrypted passwords"() {
         when:
             def context = defaultTestSpringApplicationBuilder()


### PR DESCRIPTION
These tests are passing since 6f8ee97da7599cdfbf9a213f6350f5016c260556 (see: #97).