### PR TITLE
Fix #244 - Missing test checking type of service instance payload added.

### DIFF
--- a/micro-deps/micro-deps-spring-config/src/test/groovy/com/ofg/infrastructure/discovery/ServiceInstancePayloadSpec.groovy
+++ b/micro-deps/micro-deps-spring-config/src/test/groovy/com/ofg/infrastructure/discovery/ServiceInstancePayloadSpec.groovy
@@ -1,0 +1,44 @@
+package com.ofg.infrastructure.discovery
+
+import com.ofg.infrastructure.discovery.config.PropertySourceConfiguration
+import groovyjarjarantlr.collections.List
+import org.apache.curator.x.discovery.ServiceDiscovery
+import org.apache.curator.x.discovery.ServiceInstance
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.context.annotation.Import
+import org.springframework.core.io.Resource
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.context.ContextConfiguration
+import spock.lang.Specification
+
+import static com.ofg.config.BasicProfiles.TEST
+
+@ContextConfiguration(classes = Config)
+@ActiveProfiles(TEST)
+class ServiceInstancePayloadSpec extends Specification {
+
+    @Autowired ServiceDiscovery serviceDiscovery
+
+    def 'should payload of every service instance be instance details'() {
+        given:
+            List<ServiceInstance> instances = serviceDiscovery.queryForInstances('com/ofg/stub-runner/tester') as List
+        expect:
+            instances.each { assert it.payload.class == InstanceDetails }
+    }
+
+    @Configuration
+    @Import([PropertySourceConfiguration, ServiceResolverConfiguration])
+    static class Config {
+
+        @Bean
+        ServiceConfigurationResolver serviceConfigurationResolver(
+                @Value('${microservice.config.file}') Resource microserviceConfig) {
+            return new ServiceConfigurationResolver(microserviceConfig.inputStream.text)
+        }
+
+    }
+
+}

--- a/micro-deps/micro-deps-spring-config/src/test/groovy/com/ofg/infrastructure/discovery/ServiceResolverSpec.groovy
+++ b/micro-deps/micro-deps-spring-config/src/test/groovy/com/ofg/infrastructure/discovery/ServiceResolverSpec.groovy
@@ -34,7 +34,7 @@ class ServiceResolverSpec extends Specification {
 
     void setupStubs(ServiceConfigurationResolver serviceConfigurationResolver, CuratorFramework curatorFramework) {
         serviceConfigurationResolver.dependencies.each {
-            ServiceInstance<Void> serviceInstance = ServiceInstance.builder().uriSpec(new UriSpec("{scheme}://{address}:{port}/${it.value[PATH]}"))
+            ServiceInstance<InstanceDetails> serviceInstance = ServiceInstance.builder().uriSpec(new UriSpec("{scheme}://{address}:{port}/${it.value[PATH]}"))
                     .address('localhost')
                     .port(8030)
                     .name(it.key)

--- a/micro-deps/micro-deps/src/test/groovy/com/ofg/infrastructure/base/SpecWithZookeper.groovy
+++ b/micro-deps/micro-deps/src/test/groovy/com/ofg/infrastructure/base/SpecWithZookeper.groovy
@@ -18,7 +18,7 @@ class SpecWithZookeper extends Specification {
 
     TestingServer server
     ServiceConfigurationResolver serviceConfigurationResolver
-    ServiceInstance<Void> serviceInstance
+    ServiceInstance<InstanceDetails> serviceInstance
     CuratorFramework curatorFramework
     ServiceDiscovery serviceDiscovery
     


### PR DESCRIPTION
Test checking whether payload of a service instance found by service discovery has proper type, i.e. it is `InstanceDetails`.