### PR TITLE
Issues/258 long port allocation in test

### DIFF
--- a/stub-runner/stub-runner/src/main/groovy/com/ofg/stub/server/AvailablePortScanner.groovy
+++ b/stub-runner/stub-runner/src/main/groovy/com/ofg/stub/server/AvailablePortScanner.groovy
@@ -23,14 +23,13 @@ class AvailablePortScanner {
     }
 
     public <T> T tryToExecuteWithFreePort(Closure<T> closure) {
-        int counter = maxRetryCount
-        while (--counter > 0) {
+        for (i in (1..maxRetryCount)) {
             try {
                 int portToScan = RandomUtils.nextInt(maxPortNumber - minPortNumber) + minPortNumber
                 checkIfPortIsAvailable(portToScan)
                 return executeLogicForAvailablePort(portToScan, closure)
             } catch (Exception exception) {
-                log.debug("Failed to execute closure (counter: $counter)", exception)
+                log.debug("Failed to execute closure (try: $i/$maxRetryCount)", exception)
             }
         }
         throw new NoPortAvailableException(minPortNumber, maxPortNumber)

--- a/stub-runner/stub-runner/src/test/groovy/com/ofg/stub/server/AvailablePortScannerSpec.groovy
+++ b/stub-runner/stub-runner/src/test/groovy/com/ofg/stub/server/AvailablePortScannerSpec.groovy
@@ -14,9 +14,10 @@ class AvailablePortScannerSpec extends Specification {
         given:
             AvailablePortScanner portScanner = new AvailablePortScanner(MIN_PORT, MAX_PORT)
         when:
-            portScanner.tryToExecuteWithFreePort {}
+            int usedPort = portScanner.tryToExecuteWithFreePort { int port -> port }
         then:
             noExceptionThrown()
+            usedPort == MIN_PORT
     }
 
     def 'should throw exception when free port number cannot be found'() {
@@ -47,5 +48,4 @@ class AvailablePortScannerSpec extends Specification {
             MAX_PORT | MIN_PORT
             MIN_PORT | MIN_PORT
     }
-
 }

--- a/stub-runner/stub-runner/src/test/groovy/com/ofg/stub/server/AvailablePortScannerSpec.groovy
+++ b/stub-runner/stub-runner/src/test/groovy/com/ofg/stub/server/AvailablePortScannerSpec.groovy
@@ -8,6 +8,7 @@ class AvailablePortScannerSpec extends Specification {
 
     private static final int MIN_PORT = 8989
     private static final int MAX_PORT = 8990
+    private static final int MAX_RETRY_COUNT_FOR_NEGATIVE_SCENARIOS = 2
 
     def 'should execute given closure with the next available port number'() {
         given:
@@ -23,7 +24,7 @@ class AvailablePortScannerSpec extends Specification {
             TestingServer server1 = new TestingServer(MIN_PORT, true)
             TestingServer server2 = new TestingServer(MAX_PORT, true)
         when:
-            new AvailablePortScanner(MIN_PORT, MAX_PORT).tryToExecuteWithFreePort {}
+            new AvailablePortScanner(MIN_PORT, MAX_PORT, MAX_RETRY_COUNT_FOR_NEGATIVE_SCENARIOS).tryToExecuteWithFreePort {}
         then:
             def ex = thrown(AvailablePortScanner.NoPortAvailableException)
             ex.message == "Could not find available port in range $MIN_PORT:$MAX_PORT"
@@ -35,7 +36,7 @@ class AvailablePortScannerSpec extends Specification {
     @Unroll("should throw exception for improper range [#minPort:#maxPort]")
     def 'should throw exception when improper range has been provided'() {
         given:
-            AvailablePortScanner portScanner = new AvailablePortScanner(minPort, maxPort)
+            AvailablePortScanner portScanner = new AvailablePortScanner(minPort, maxPort, MAX_RETRY_COUNT_FOR_NEGATIVE_SCENARIOS)
         when:
             portScanner.tryToExecuteWithFreePort {}
         then:


### PR DESCRIPTION
It is possible to (optionally) specify the number of retries to perform in `AvailablePortScanner`.

In negative scenarios `AvailablePortScannerSpec` tried to allocate not allocable port 2x1000 times. Running those tests from Idea it took 17 second (now 2s), but on Travis socket operations can be more expensive (and maybe those modifications will fix "hanging" tests in Travis).

By the way the loop is groovier and has better debug message ( `range` with `each {}` cannot be used as there is a problem with embedded return).