### PR TITLE
Shared properties across environments

### DIFF
--- a/micro-infra-spring-config/src/main/java/com/ofg/infrastructure/property/ConfigLocations.java
+++ b/micro-infra-spring-config/src/main/java/com/ofg/infrastructure/property/ConfigLocations.java
@@ -1,0 +1,88 @@
+package com.ofg.infrastructure.property;
+
+import com.google.common.base.Function;
+import com.google.common.base.MoreObjects;
+import com.google.common.collect.Lists;
+
+import java.io.File;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.List;
+
+class ConfigLocations {
+
+    /**
+     * Shared properties across environments.
+     */
+    private final File commonDir;
+
+    /**
+     * Properties environment specific.
+     */
+    private final File envDir;
+
+    /**
+     * Properties country specific.
+     */
+    private final File countryDir;
+
+    ConfigLocations(File commonDir, File envDir, File countryDir) {
+        this.commonDir = commonDir;
+        this.envDir = envDir;
+        this.countryDir = countryDir;
+    }
+
+    List<Path> getConfigPaths() {
+        return Lists.transform(getAllDirs(), new Function<File, Path>() {
+            @Override
+            public Path apply(File dir) {
+                return dir.toPath();
+            }
+        });
+    }
+
+    File commonPropertiesFile(String name) {
+        return propertiesFile(commonDir, name);
+    }
+
+    File commonYamlFile(String name) {
+        return yamlFile(commonDir, name);
+    }
+
+    File envPropertiesFile(String name) {
+        return propertiesFile(envDir, name);
+    }
+
+    File envYamlFile(String name) {
+        return yamlFile(envDir, name);
+    }
+
+    File countryPropertiesFile(String name) {
+        return propertiesFile(countryDir, name);
+    }
+
+    File countryYamlFile(String name) {
+        return yamlFile(countryDir, name);
+    }
+
+    @Override
+    public String toString() {
+        return MoreObjects.toStringHelper(this)
+                .add("commonDir", commonDir)
+                .add("envDir", envDir)
+                .add("countryDir", countryDir)
+                .toString();
+    }
+
+    private List<File> getAllDirs() {
+        return Arrays.asList(commonDir, envDir, countryDir);
+    }
+
+    private File propertiesFile(File parent, String name) {
+        return new File(parent, name + ".properties");
+    }
+
+    private File yamlFile(File parent, String name) {
+        return new File(parent, name + ".yaml");
+    }
+}

--- a/micro-infra-spring-config/src/main/java/com/ofg/infrastructure/property/FileSystemLocator.java
+++ b/micro-infra-spring-config/src/main/java/com/ofg/infrastructure/property/FileSystemLocator.java
@@ -69,8 +69,8 @@ public class FileSystemLocator implements PropertySourceLocator {
         return composite;
     }
 
-    public File getConfigDir() {
-        return appCoordinates.getConfigFolder(propertiesFolder);
+    public ConfigLocations getConfigLocations() {
+        return appCoordinates.getConfigLocations(propertiesFolder);
     }
 
     private Map<String, Object> decrypt(Map<String, Object> sourceMap) {

--- a/micro-infra-spring-config/src/test/groovy/com/ofg/infrastructure/property/AppCoordinatesTest.groovy
+++ b/micro-infra-spring-config/src/test/groovy/com/ofg/infrastructure/property/AppCoordinatesTest.groovy
@@ -16,27 +16,39 @@ class AppCoordinatesTest extends Specification {
 
         where:
             env        | country | name                                   || paths
-            'prod'     | 'pl'    | 'foo'                                  || ['/prod/foo.properties',
+            'prod'     | 'pl'    | 'foo'                                  || ['/common/foo.properties',
+                                                                              '/common/foo.yaml',
+                                                                              '/prod/foo.properties',
                                                                               '/prod/foo.yaml',
                                                                               '/prod/pl/foo-pl.properties',
                                                                               '/prod/pl/foo-pl.yaml']
-            'prod'     | 'pl'    | '/a/b/c'                               || ['/prod/a/b/c.properties',
+            'prod'     | 'pl'    | '/a/b/c'                               || ['/common/a/b/c.properties',
+                                                                              '/common/a/b/c.yaml',
+                                                                              '/prod/a/b/c.properties',
                                                                               '/prod/a/b/c.yaml',
                                                                               '/prod/a/b/pl/c-pl.properties',
                                                                               '/prod/a/b/pl/c-pl.yaml']
-            'dev'      | 'es'    | '/com/ofg/fraud-es'                    || ['/dev/com/ofg/fraud.properties',
+            'dev'      | 'es'    | '/com/ofg/fraud-es'                    || ['/common/com/ofg/fraud.properties',
+                                                                              '/common/com/ofg/fraud.yaml',
+                                                                              '/dev/com/ofg/fraud.properties',
                                                                               '/dev/com/ofg/fraud.yaml',
                                                                               '/dev/com/ofg/es/fraud-es.properties',
                                                                               '/dev/com/ofg/es/fraud-es.yaml']
-            'dev'      | 'pl'    | '/com/ofg/pl/fraud-pl'                 || ['/dev/com/ofg/fraud.properties',
+            'dev'      | 'pl'    | '/com/ofg/pl/fraud-pl'                 || ['/common/com/ofg/fraud.properties',
+                                                                              '/common/com/ofg/fraud.yaml',
+                                                                              '/dev/com/ofg/fraud.properties',
                                                                               '/dev/com/ofg/fraud.yaml',
                                                                               '/dev/com/ofg/pl/fraud-pl.properties',
                                                                               '/dev/com/ofg/pl/fraud-pl.yaml']
-            'dev'      | 'pl'    | '/com/ofg/pl/fraud'                    || ['/dev/com/ofg/fraud.properties',
+            'dev'      | 'pl'    | '/com/ofg/pl/fraud'                    || ['/common/com/ofg/fraud.properties',
+                                                                              '/common/com/ofg/fraud.yaml',
+                                                                              '/dev/com/ofg/fraud.properties',
                                                                               '/dev/com/ofg/fraud.yaml',
                                                                               '/dev/com/ofg/pl/fraud-pl.properties',
                                                                               '/dev/com/ofg/pl/fraud-pl.yaml']
-            'stage-01' | 'ro'    | 'com/ofg/loans/ro/backoffice-vivus-ro' || ['/stage-01/com/ofg/loans/backoffice-vivus.properties',
+            'stage-01' | 'ro'    | 'com/ofg/loans/ro/backoffice-vivus-ro' || ['/common/com/ofg/loans/backoffice-vivus.properties',
+                                                                              '/common/com/ofg/loans/backoffice-vivus.yaml',
+                                                                              '/stage-01/com/ofg/loans/backoffice-vivus.properties',
                                                                               '/stage-01/com/ofg/loans/backoffice-vivus.yaml',
                                                                               '/stage-01/com/ofg/loans/ro/backoffice-vivus-ro.properties',
                                                                               '/stage-01/com/ofg/loans/ro/backoffice-vivus-ro.yaml']

--- a/micro-infra-spring-config/src/test/groovy/com/ofg/infrastructure/property/ConfigLocationsTest.groovy
+++ b/micro-infra-spring-config/src/test/groovy/com/ofg/infrastructure/property/ConfigLocationsTest.groovy
@@ -1,0 +1,46 @@
+package com.ofg.infrastructure.property
+
+import spock.lang.Specification
+
+class ConfigLocationsTest extends Specification {
+
+    static final File COMMON_DIR = new File('props', 'common')
+    static final File ENV_DIR = new File('props', 'prod')
+    static final File COUNTRY_DIR = new File(ENV_DIR, 'pl')
+
+    static final String TEST_BASE_NAME = 'test'
+    static final String TEST_PROPERTIES = 'test.properties'
+    static final String TEST_YAML = 'test.yaml'
+
+    ConfigLocations configDirs = new ConfigLocations(COMMON_DIR, ENV_DIR, COUNTRY_DIR)
+
+    def 'should return correct common properties file'() {
+        expect:
+            configDirs.commonPropertiesFile(TEST_BASE_NAME) == new File(COMMON_DIR, TEST_PROPERTIES)
+    }
+
+    def 'should return correct common yaml file'() {
+        expect:
+            configDirs.commonYamlFile(TEST_BASE_NAME) == new File(COMMON_DIR, TEST_YAML)
+    }
+
+    def 'should return correct env properties file'() {
+        expect:
+            configDirs.envPropertiesFile(TEST_BASE_NAME) == new File(ENV_DIR, TEST_PROPERTIES)
+    }
+
+    def 'should return correct env yaml file'() {
+        expect:
+            configDirs.envYamlFile(TEST_BASE_NAME) == new File(ENV_DIR, TEST_YAML)
+    }
+
+    def 'should return correct country properties file'() {
+        expect:
+            configDirs.countryPropertiesFile(TEST_BASE_NAME) == new File(COUNTRY_DIR, TEST_PROPERTIES)
+    }
+
+    def 'should create correct country yaml file'() {
+        expect:
+            configDirs.countryYamlFile(TEST_BASE_NAME) == new File(COUNTRY_DIR, TEST_YAML)
+    }
+}

--- a/micro-infra-spring-config/src/test/groovy/com/ofg/infrastructure/property/LoadingFromFileSystemTest.groovy
+++ b/micro-infra-spring-config/src/test/groovy/com/ofg/infrastructure/property/LoadingFromFileSystemTest.groovy
@@ -28,19 +28,29 @@ class LoadingFromFileSystemTest extends AbstractIntegrationTest {
         myBean = context.getBean(MyBean)
     }
 
-    def 'should read property from default .properties file'() {
+    def 'should read property from common .properties file'() {
         expect:
-            myBean.globalPropKey == 'global prop value'
+            myBean.commonPropKey == 'common prop value'
     }
 
-    def 'should read property from default .yaml file'() {
+    def 'should read property from env .properties file'() {
         expect:
-            myBean.countryPropKey == 'country prop value'
+            myBean.envPropKey == 'env prop value'
     }
 
     def 'should read property from country-specific .properties file'() {
         expect:
-            myBean.globalYamlKey == 'global yaml value'
+            myBean.countryPropKey == 'country prop value'
+    }
+
+    def 'should read property from common .yaml file'() {
+        expect:
+            myBean.commonYamlKey == 'common yaml value'
+    }
+
+    def 'should read property from env .yaml file'() {
+        expect:
+            myBean.envYamlKey == 'env yaml value'
     }
 
     def 'should read property from country-specific .yaml file'() {
@@ -50,18 +60,19 @@ class LoadingFromFileSystemTest extends AbstractIntegrationTest {
 
     def 'should override property from country-specific .properties file'() {
         expect:
-            myBean.globalDefaultKey == 'overridden default value'
+            myBean.commonDefaultPropKey == 'overridden country-specific prop value'
     }
 
     def 'should override property from country-specific .yaml file'() {
         expect:
-            myBean.globalYamlDefault == 'overridden default yaml value'
+            myBean.commonDefaultYamlKey == 'overridden country-specific yaml value'
     }
 
     def '.yaml has priority over .properties'() {
         expect:
-            myBean.custom == 'yaml value'
-            myBean.customCountry == 'yaml country value'
+            myBean.customCommonKey == 'custom common yaml value'
+            myBean.customEnvKey == 'custom env yaml value'
+            myBean.customCountryKey == 'custom country yaml value'
     }
 }
 
@@ -77,27 +88,38 @@ class BasicApp {
 }
 
 class MyBean {
-    @Value('${global.prop.key}')
-    String globalPropKey;
+
+    @Value('${common.prop.key}')
+    String commonPropKey
+
+    @Value('${env.prop.key}')
+    String envPropKey
 
     @Value('${country.prop.key}')
-    String countryPropKey;
+    String countryPropKey
 
-    @Value('${global.yaml.key}')
-    String globalYamlKey;
+    @Value('${common.yaml.key}')
+    String commonYamlKey
+
+    @Value('${env.yaml.key}')
+    String envYamlKey
 
     @Value('${country.yaml.key}')
-    String countryYamlKey;
+    String countryYamlKey
 
-    @Value('${global.default.key}')
-    String globalDefaultKey;
+    @Value('${common.default.prop.key}')
+    String commonDefaultPropKey
 
-    @Value('${global.yaml.default}')
-    String globalYamlDefault;
+    @Value('${common.default.yaml.key}')
+    String commonDefaultYamlKey
 
-    @Value('${custom}')
-    String custom;
+    @Value('${custom.common.key}')
+    String customCommonKey
 
-    @Value('${custom.country}')
-    String customCountry;
+    @Value('${custom.env.key}')
+    String customEnvKey
+
+    @Value('${custom.country.key}')
+    String customCountryKey
+
 }

--- a/micro-infra-spring-config/src/test/resources/microservice-enc.json
+++ b/micro-infra-spring-config/src/test/resources/microservice-enc.json
@@ -1,5 +1,5 @@
 {
-    "nn": {
+    "pl": {
         "this": "/com/ofg/micro-app-enc"
     }
 }

--- a/micro-infra-spring-config/src/test/resources/test-config-dir/common/com/ofg/micro-app.properties
+++ b/micro-infra-spring-config/src/test/resources/test-config-dir/common/com/ofg/micro-app.properties
@@ -1,0 +1,3 @@
+common.prop.key=common prop value
+common.default.prop.key=common default prop value
+custom.common.key=custom common prop value

--- a/micro-infra-spring-config/src/test/resources/test-config-dir/common/com/ofg/micro-app.yaml
+++ b/micro-infra-spring-config/src/test/resources/test-config-dir/common/com/ofg/micro-app.yaml
@@ -1,0 +1,9 @@
+common:
+  yaml:
+    key: common yaml value
+  default:
+    yaml:
+      key: common default yaml value
+custom:
+  common:
+    key: custom common yaml value

--- a/micro-infra-spring-config/src/test/resources/test-config-dir/prod/com/ofg/micro-app.properties
+++ b/micro-infra-spring-config/src/test/resources/test-config-dir/prod/com/ofg/micro-app.properties
@@ -1,3 +1,3 @@
-global.prop.key=global prop value
-global.default.key=global default value
-custom=prop value
+env.prop.key=env prop value
+common.default.prop.key=overridden env prop value
+custom.env.key=custom env prop value

--- a/micro-infra-spring-config/src/test/resources/test-config-dir/prod/com/ofg/micro-app.yaml
+++ b/micro-infra-spring-config/src/test/resources/test-config-dir/prod/com/ofg/micro-app.yaml
@@ -1,5 +1,10 @@
-global:
+env:
   yaml:
-    key: global yaml value
-    default: global default yaml value
-custom: yaml value
+    key: env yaml value
+common:
+  default:
+    yaml:
+      key: overridden env yaml value
+custom:
+  env:
+    key: custom env yaml value

--- a/micro-infra-spring-config/src/test/resources/test-config-dir/prod/com/ofg/pl/micro-app-pl.properties
+++ b/micro-infra-spring-config/src/test/resources/test-config-dir/prod/com/ofg/pl/micro-app-pl.properties
@@ -1,3 +1,3 @@
 country.prop.key=country prop value
-global.default.key=overridden default value
-custom.country=prop country value
+common.default.prop.key=overridden country-specific prop value
+custom.country.key=custom country prop value

--- a/micro-infra-spring-config/src/test/resources/test-config-dir/prod/com/ofg/pl/micro-app-pl.yaml
+++ b/micro-infra-spring-config/src/test/resources/test-config-dir/prod/com/ofg/pl/micro-app-pl.yaml
@@ -1,8 +1,10 @@
 country:
   yaml:
     key: country yaml value
-global:
-  yaml:
-    default: overridden default yaml value
+common:
+  default:
+   yaml:
+     key: overridden country-specific yaml value
 custom:
-  country: yaml country value
+  country:
+   key: custom country yaml value


### PR DESCRIPTION
This pull request introduces a new configuration location called `common`. This configuration can be shared across all envirenments. `common` dir is located next to dev, test or prod and has lowest priority (comparing with env and country locations).

Additionally a bug in FileSystemPoller was fixed. It took into account only changes in an env location and ignored changes in a country location. Now poller watches common, env and country locations.

Example configuration files were adjusted to cover in test different scenarios with priorities.

Tiny refactorings were introduced as well.
