### PR TITLE
Use Spec suffix in Spock specifications

### DIFF
--- a/micro-infra-spring-base/src/test/groovy/com/ofg/infrastructure/correlationid/CorrelationIdUpdaterSpec.groovy
+++ b/micro-infra-spring-base/src/test/groovy/com/ofg/infrastructure/correlationid/CorrelationIdUpdaterSpec.groovy
@@ -11,7 +11,7 @@ import java.util.concurrent.Executors
 import static java.util.concurrent.TimeUnit.SECONDS
 
 
-class CorrelationIdUpdaterTest extends Specification {
+class CorrelationIdUpdaterSpec extends Specification {
 
     def cleanup() {
         CorrelationIdHolder.remove()

--- a/micro-infra-spring-base/src/test/groovy/com/ofg/infrastructure/hystrix/CorrelatedCommandSpec.groovy
+++ b/micro-infra-spring-base/src/test/groovy/com/ofg/infrastructure/hystrix/CorrelatedCommandSpec.groovy
@@ -8,7 +8,7 @@ import static com.netflix.hystrix.HystrixCommand.Setter.withGroupKey
 import static com.netflix.hystrix.HystrixCommandGroupKey.Factory.asKey
 
 
-class CorrelatedCommandTest extends Specification {
+class CorrelatedCommandSpec extends Specification {
 
     public static final String CORRELATION_ID = 'A'
 

--- a/micro-infra-spring-base/src/test/groovy/com/ofg/infrastructure/web/correlationid/CorrelationIdFilterSkipPatternSpec.groovy
+++ b/micro-infra-spring-base/src/test/groovy/com/ofg/infrastructure/web/correlationid/CorrelationIdFilterSkipPatternSpec.groovy
@@ -12,7 +12,7 @@ import static com.ofg.infrastructure.correlationid.CorrelationIdHolder.CORRELATI
 
 
 @Unroll
-class CorrelationIdFilterSkipPatternTest extends Specification {
+class CorrelationIdFilterSkipPatternSpec extends Specification {
 
     CorrelationIdFilter filter = new CorrelationIdFilter(Stub(UuidGenerator), CorrelationIdFilter.DEFAULT_SKIP_PATTERN)
 

--- a/micro-infra-spring-base/src/test/groovy/com/ofg/infrastructure/web/resttemplate/custom/InputStreamPrinterSpec.groovy
+++ b/micro-infra-spring-base/src/test/groovy/com/ofg/infrastructure/web/resttemplate/custom/InputStreamPrinterSpec.groovy
@@ -4,7 +4,7 @@ import spock.lang.Specification
 import spock.lang.Unroll
 
 @Unroll
-class InputStreamPrinterTest extends Specification {
+class InputStreamPrinterSpec extends Specification {
 
     def 'should abbreviate "#source" to "#target" with max chars #maxChars'() {
         given:

--- a/micro-infra-spring-base/src/test/groovy/com/ofg/infrastructure/web/resttemplate/fluent/common/response/executor/RestExecutorSpec.groovy
+++ b/micro-infra-spring-base/src/test/groovy/com/ofg/infrastructure/web/resttemplate/fluent/common/response/executor/RestExecutorSpec.groovy
@@ -6,7 +6,7 @@ import org.springframework.http.HttpMethod
 import org.springframework.web.client.ResourceAccessException
 import spock.lang.Specification
 
-class RestExecutorTest extends Specification {
+class RestExecutorSpec extends Specification {
 
     def "should fail to run asynchronously if retry mechanism wasn't set up"() {
         given:

--- a/micro-infra-spring-config/src/test/groovy/com/ofg/infrastructure/property/AbstractIntegrationSpec.groovy
+++ b/micro-infra-spring-config/src/test/groovy/com/ofg/infrastructure/property/AbstractIntegrationSpec.groovy
@@ -6,7 +6,7 @@ import spock.util.environment.RestoreSystemProperties
 
 @RestoreSystemProperties
 @ClassLevelRestoreSystemProperties
-abstract class AbstractIntegrationTest extends Specification {
+abstract class AbstractIntegrationSpec extends Specification {
 
     public static final String CLOUD_SERVER_ENALED = "spring.cloud.config.server.enabled"
 

--- a/micro-infra-spring-config/src/test/groovy/com/ofg/infrastructure/property/AppCoordinatesSpec.groovy
+++ b/micro-infra-spring-config/src/test/groovy/com/ofg/infrastructure/property/AppCoordinatesSpec.groovy
@@ -5,7 +5,7 @@ import spock.lang.Unroll
 
 
 @Unroll
-class AppCoordinatesTest extends Specification {
+class AppCoordinatesSpec extends Specification {
 
     def 'should properly resolve config files for name #name'() {
         given:

--- a/micro-infra-spring-config/src/test/groovy/com/ofg/infrastructure/property/ConfigLocationsSpec.groovy
+++ b/micro-infra-spring-config/src/test/groovy/com/ofg/infrastructure/property/ConfigLocationsSpec.groovy
@@ -2,7 +2,7 @@ package com.ofg.infrastructure.property
 
 import spock.lang.Specification
 
-class ConfigLocationsTest extends Specification {
+class ConfigLocationsSpec extends Specification {
 
     static final File COMMON_DIR = new File('props', 'common')
     static final File ENV_DIR = new File('props', 'prod')

--- a/micro-infra-spring-config/src/test/groovy/com/ofg/infrastructure/property/FileSystemPollerSpec.groovy
+++ b/micro-infra-spring-config/src/test/groovy/com/ofg/infrastructure/property/FileSystemPollerSpec.groovy
@@ -18,7 +18,7 @@ import javax.annotation.PostConstruct
 import java.util.concurrent.atomic.AtomicInteger
 
 @IgnoreIf({ os.macOs }) //Due to problems with native file system poller implementation - https://github.com/4finance/micro-infra-spring/issues/119
-class FileSystemPollerTest extends AbstractIntegrationTest {
+class FileSystemPollerSpec extends AbstractIntegrationSpec {
 
     private static final String MICROSERVICE_NAME = 'micro-app'
     private static final String PL_MICROSERVICE_NAME = MICROSERVICE_NAME + '-pl'

--- a/micro-infra-spring-config/src/test/groovy/com/ofg/infrastructure/property/LoadingFromFileSystemSpec.groovy
+++ b/micro-infra-spring-config/src/test/groovy/com/ofg/infrastructure/property/LoadingFromFileSystemSpec.groovy
@@ -11,7 +11,7 @@ import org.springframework.context.annotation.Configuration
 import spock.lang.AutoCleanup
 import spock.lang.Shared
 
-class LoadingFromFileSystemTest extends AbstractIntegrationTest {
+class LoadingFromFileSystemSpec extends AbstractIntegrationSpec {
 
     @Shared
     @AutoCleanup

--- a/micro-infra-spring-config/src/test/groovy/com/ofg/infrastructure/property/decrypt/BrokenJceInstallationSpec.groovy
+++ b/micro-infra-spring-config/src/test/groovy/com/ofg/infrastructure/property/decrypt/BrokenJceInstallationSpec.groovy
@@ -8,7 +8,7 @@ import static com.ofg.infrastructure.property.decrypt.JceUnlimitedStrengthTestFi
 import static com.ofg.infrastructure.property.decrypt.JceUnlimitedStrengthTestFixture.strongEncryptionSupported
 
 @IgnoreIf({ isPropertiesDecryptionTestingExplicitDisabled() })
-class BrokenJceInstallationTest extends Specification {
+class BrokenJceInstallationSpec extends Specification {
 
     def "JCE US has to be installed for property values decryption - see exception message how to disable that"() {
         expect:

--- a/micro-infra-spring-config/src/test/groovy/com/ofg/infrastructure/property/decrypt/DecryptingPropertyExtendedSpec.groovy
+++ b/micro-infra-spring-config/src/test/groovy/com/ofg/infrastructure/property/decrypt/DecryptingPropertyExtendedSpec.groovy
@@ -1,10 +1,10 @@
 package com.ofg.infrastructure.property.decrypt
 
-import com.ofg.infrastructure.property.AbstractIntegrationTest
+import com.ofg.infrastructure.property.AbstractIntegrationSpec
 import org.codehaus.groovy.runtime.StackTraceUtils
 import org.springframework.boot.builder.SpringApplicationBuilder
 
-class DecryptingPropertyExtendedTest extends AbstractIntegrationTest {
+class DecryptingPropertyExtendedSpec extends AbstractIntegrationSpec {
 
     def "should fail when wrong encryption key is provided and there are encrypted passwords"() {
         given:

--- a/micro-infra-spring-config/src/test/groovy/com/ofg/infrastructure/property/decrypt/DecryptingPropertySpec.groovy
+++ b/micro-infra-spring-config/src/test/groovy/com/ofg/infrastructure/property/decrypt/DecryptingPropertySpec.groovy
@@ -1,6 +1,6 @@
 package com.ofg.infrastructure.property.decrypt
 
-import com.ofg.infrastructure.property.AbstractIntegrationTest
+import com.ofg.infrastructure.property.AbstractIntegrationSpec
 import org.springframework.boot.builder.SpringApplicationBuilder
 import org.springframework.boot.context.properties.ConfigurationProperties
 import org.springframework.boot.context.properties.EnableConfigurationProperties
@@ -17,7 +17,7 @@ import spock.lang.Shared
 import static com.ofg.infrastructure.property.decrypt.JceUnlimitedStrengthTestFixture.shouldDecryptionTestsBeExecuted
 
 @IgnoreIf({ !shouldDecryptionTestsBeExecuted() })
-class DecryptingPropertyTest extends AbstractIntegrationTest {
+class DecryptingPropertySpec extends AbstractIntegrationSpec {
 
     @Shared
     @AutoCleanup

--- a/micro-infra-spring-config/src/test/groovy/com/ofg/infrastructure/property/decrypt/LoadingEncryptedFromFileSystemSpec.groovy
+++ b/micro-infra-spring-config/src/test/groovy/com/ofg/infrastructure/property/decrypt/LoadingEncryptedFromFileSystemSpec.groovy
@@ -1,6 +1,6 @@
 package com.ofg.infrastructure.property.decrypt
 
-import com.ofg.infrastructure.property.AbstractIntegrationTest
+import com.ofg.infrastructure.property.AbstractIntegrationSpec
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration
 import org.springframework.boot.builder.SpringApplicationBuilder
@@ -16,7 +16,7 @@ import spock.lang.Shared
 import static com.ofg.infrastructure.property.decrypt.JceUnlimitedStrengthTestFixture.shouldDecryptionTestsBeExecuted
 
 @IgnoreIf({ !shouldDecryptionTestsBeExecuted() })
-class LoadingEncryptedFromFileSystemTest extends AbstractIntegrationTest {
+class LoadingEncryptedFromFileSystemSpec extends AbstractIntegrationSpec {
 
     @Shared
     @AutoCleanup


### PR DESCRIPTION
The majority of our Spock specifications has `Spec` suffix in name, so let's be consistent with all specifications.