### PR TITLE
Upgrade Spring Boot to 1.2.2 and Hystrix to 1.4.0-rc.9

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 buildscript {
     ext {
-        springBootVersion = "1.2.1.RELEASE"
+        springBootVersion = "1.2.2.RELEASE"
     }
     repositories {
         mavenLocal()
@@ -74,7 +74,7 @@ allprojects {
                         details.useTarget("org.codehaus.groovy:groovy-all:${details.requested.version}")
                     }
                     if (details.requested.group == 'org.springframework.boot') { details.useVersion springBootVersion }
-                    if (details.requested.group == 'org.springframework') { details.useVersion "4.1.4.RELEASE" }
+                    if (details.requested.group == 'org.springframework') { details.useVersion "4.1.5.RELEASE" }
                     if (details.requested.group == 'org.aspectj') { details.useVersion "1.8.4" }
                 }
             }

--- a/micro-infra-spring-base/build.gradle
+++ b/micro-infra-spring-base/build.gradle
@@ -3,7 +3,7 @@ description = 'Microservice base infrastructure registered in Spring'
 ext {
     metricsVersion = '3.1.0'
     jacksonMapper = '1.9.13'
-    hystrixVersion = '1.4.0-RC6'
+    hystrixVersion = '1.4.0-rc.9'
 }
 
 sourceSets.main.java.srcDirs = []
@@ -34,7 +34,7 @@ dependencies {
     testCompile 'org.hamcrest:hamcrest-library:1.3'
     testCompile 'org.hibernate:hibernate-validator:5.1.3.Final'
     testCompile 'com.jayway.jsonpath:json-path-assert:1.2.0'
-    testCompile 'com.github.stefanbirkner:system-rules:1.8.0'
+    testCompile 'com.github.stefanbirkner:system-rules:1.9.0'
     testCompile project(':micro-infra-spring-test')
     testCompile 'org.codehaus.gpars:gpars:1.2.1'
 }

--- a/micro-infra-spring-base/src/test/groovy/com/ofg/infrastructure/hystrix/CircuitBreakers.groovy
+++ b/micro-infra-spring-base/src/test/groovy/com/ofg/infrastructure/hystrix/CircuitBreakers.groovy
@@ -2,16 +2,19 @@ package com.ofg.infrastructure.hystrix
 
 import com.netflix.hystrix.HystrixCommand
 import com.netflix.hystrix.HystrixCommandProperties
+import groovy.transform.CompileStatic
 
 import static com.netflix.hystrix.HystrixCommand.Setter.withGroupKey
 import static com.netflix.hystrix.HystrixCommandGroupKey.Factory.asKey
 
+@CompileStatic
 class CircuitBreakers {
 
     static HystrixCommand.Setter anyWithTimeout(int timeoutInMillis) {
         //below workaround comes from https://jira.codehaus.org/browse/GROOVY-6286
-        HystrixCommandProperties.Setter commandPropertiesSetter = HystrixCommandProperties.invokeMethod("Setter", null)
-        return any().andCommandPropertiesDefaults(commandPropertiesSetter.withTimeoutInMilliseconds(timeoutInMillis))
+        HystrixCommandProperties.Setter commandPropertiesSetter =
+                (HystrixCommandProperties.Setter)HystrixCommandProperties.invokeMethod("Setter", null)
+        return any().andCommandPropertiesDefaults(commandPropertiesSetter.withExecutionTimeoutInMilliseconds(timeoutInMillis))
     }
 
     static HystrixCommand.Setter any() {


### PR DESCRIPTION
Also Spring Framework upgraded to 4.1.5 (needed by Spring Boot).

**Inportant notes**. Spring 4.1.5 is minimal required versions to not fail in runtime (due to [that](https://github.com/spring-projects/spring-framework/blob/master/spring-web/src/main/java/org/springframework/http/converter/json/Jackson2ObjectMapperBuilder.java#L434). It should be put into release notes.