### PR TITLE
Issues/245 grapes not working

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.2.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.2.1-bin.zip

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Thu Jan 08 13:54:43 CET 2015
+#Sun Mar 08 14:26:04 CET 2015
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.2.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.2.1-all.zip

--- a/stub-runner/stub-runner-spring/src/main/groovy/com/ofg/stub/config/StubRunnerConfiguration.groovy
+++ b/stub-runner/stub-runner-spring/src/main/groovy/com/ofg/stub/config/StubRunnerConfiguration.groovy
@@ -72,7 +72,7 @@ class StubRunnerConfiguration {
                                 @Deprecated @Value('${stubrunner.stubs.group:com.ofg}') String stubsGroup,
                                 @Deprecated @Value('${stubrunner.stubs.module:stub-definitions}') String stubsModule,
                                 @Value('${stubrunner.stubs.suffix:stubs}') String stubsSuffx,
-                                @Value('${stubrunner.skip-local-repo:false}') boolean skipLocalRepo,
+                                @Value('${stubrunner.skip-local-repo:true}') boolean skipLocalRepo,
                                 @Value('${stubrunner.use-microservice-definitions:false}') boolean useMicroserviceDefinitions,
                                 @Value('${stubrunner.wait-for-service:false}') boolean waitForService,
                                 @Value('${stubrunner.wait-timeout:1}') Integer waitTimeout,

--- a/stub-runner/stub-runner-spring/src/main/groovy/com/ofg/stub/config/StubRunnerConfiguration.groovy
+++ b/stub-runner/stub-runner-spring/src/main/groovy/com/ofg/stub/config/StubRunnerConfiguration.groovy
@@ -58,7 +58,8 @@ class StubRunnerConfiguration {
      * @param @Deprecated stubsGroup group name of the dependency containing stub mappings
      * @param @Deprecated stubsModule module name of the dependency containing stub mappings
      * @param stubsSuffix suffix for the jar containing stubs
-     * @param skipLocalRepo avoids local repository in dependency resolution
+     * @param workOffline forces offline work
+     * @param @Deprecated skipLocalRepo avoids local repository in dependency resolution
      * @param useMicroserviceDefinitions use per microservice stub resolution rather than one jar for all microservices
      * @param waitForService wait for connection from service
      * @param waitTimeout wait timeout in seconds
@@ -72,19 +73,25 @@ class StubRunnerConfiguration {
                                 @Deprecated @Value('${stubrunner.stubs.group:com.ofg}') String stubsGroup,
                                 @Deprecated @Value('${stubrunner.stubs.module:stub-definitions}') String stubsModule,
                                 @Value('${stubrunner.stubs.suffix:stubs}') String stubsSuffx,
-                                @Value('${stubrunner.skip-local-repo:true}') boolean skipLocalRepo,
+                                @Value('${stubrunner.work-offline:false}') boolean workOffline,
+                                @Deprecated @Value('${stubrunner.skip-local-repo:true}') boolean skipLocalRepo,
                                 @Value('${stubrunner.use-microservice-definitions:false}') boolean useMicroserviceDefinitions,
                                 @Value('${stubrunner.wait-for-service:false}') boolean waitForService,
                                 @Value('${stubrunner.wait-timeout:1}') Integer waitTimeout,
                                 TestingServer testingServer,
                                 ServiceConfigurationResolver serviceConfigurationResolver) {
-        StubRunnerOptions stubRunnerOptions = new StubRunnerOptions(minPortValue, maxPortValue, stubRepositoryRoot, stubsGroup, stubsModule, skipLocalRepo,
+        boolean shouldWorkOnline = isPropertySetToWorkOnline(workOffline, skipLocalRepo)
+        StubRunnerOptions stubRunnerOptions = new StubRunnerOptions(minPortValue, maxPortValue, stubRepositoryRoot, stubsGroup, stubsModule, shouldWorkOnline,
                 useMicroserviceDefinitions, testingServer.connectString, testingServer.port, stubsSuffx, waitForService, waitTimeout)
         List<String> dependenciesPath = serviceConfigurationResolver.dependencies.collect { String alias, Map dependencyConfig ->
             return dependencyConfig[PATH]
         }
         Collaborators dependencies = new Collaborators(serviceConfigurationResolver.basePath, dependenciesPath)
         return new BatchStubRunnerFactory(stubRunnerOptions, dependencies).buildBatchStubRunner()
+    }
+
+    private boolean isPropertySetToWorkOnline(boolean workOffline, boolean skipLocalRepo) {
+        return workOffline ? false : skipLocalRepo
     }
 
 

--- a/stub-runner/stub-runner/build.gradle
+++ b/stub-runner/stub-runner/build.gradle
@@ -60,7 +60,9 @@ run {
         argumentList = parseArguments()
     }
     args = argumentList
-    println "Running task with args $args"
+    if (args) {
+        println "Running task with args $args"
+    }
 }
 
 List parseArguments() {

--- a/stub-runner/stub-runner/src/main/groovy/com/ofg/stub/StubDownloader.groovy
+++ b/stub-runner/stub-runner/src/main/groovy/com/ofg/stub/StubDownloader.groovy
@@ -59,7 +59,7 @@ class StubDownloader {
             log.info("Setting default grapes path to [$microInfraGrapePath]")
             return buildResolver(skipLocalRepo).resolveDependency(stubRepositoryRoot, depToGrab)
         } finally {
-            System.setProperty(GRAPE_CONFIG, oldGrapeConfig)
+            restoreOldGrapeConfigIfApplicable(oldGrapeConfig)
         }
     }
 
@@ -73,6 +73,12 @@ class StubDownloader {
             microInfraGrape.parentFile.mkdirs()
             microInfraGrape.createNewFile()
             microInfraGrape.text = StubDownloader.class.getResource('/microInfraGrapeConfig.xml').text
+        }
+    }
+
+    private void restoreOldGrapeConfigIfApplicable(String oldGrapeConfig) {
+        if (oldGrapeConfig) {
+            System.setProperty(GRAPE_CONFIG, oldGrapeConfig)
         }
     }
 

--- a/stub-runner/stub-runner/src/main/resources/microInfraGrapeConfig.xml
+++ b/stub-runner/stub-runner/src/main/resources/microInfraGrapeConfig.xml
@@ -1,0 +1,12 @@
+<ivysettings>
+    <settings defaultResolver="downloadGrapes"/>
+    <resolvers>
+        <chain name="downloadGrapes">
+            <ibiblio name="localm2" root="file:${user.home}/.m2/repository/" checkmodified="true" changingPattern=".*" changingMatcher="regexp" m2compatible="true"/>
+            <filesystem name="cachedGrapes">
+                <ivy pattern="${user.home}/.groovy/grapes/[organisation]/[module]/ivy-[revision].xml"/>
+                <artifact pattern="${user.home}/.groovy/grapes/[organisation]/[module]/[type]s/[artifact]-[revision](-[classifier]).[ext]"/>
+            </filesystem>
+        </chain>
+    </resolvers>
+</ivysettings>


### PR DESCRIPTION
- Changed the default flag `skip.local.repo` following this dicsussion [https://github.com/4finance/micro-infra-spring/issues/245]. Now stubs will by default be checked against local and ALSO checked against a remote repository
- The flag `skip.local.repo` turned to false will make Grape look for artifacts in the local repo. ONLY if it can't find anything will it try to search for artifacts in the remote repository.
- This functionality will create a .micro-infra-spring folder in user.home if not specified otherwise by a system property. In that folder it will create a default grape configuration that searches for artifatcs in the maven local repository and grapes cache by default.
- If the flag `skip.local.repo` is set to true it will ALSO check it in the remote repository (which actually makes the flag name somewhat obsolete - I only left it for the historical purposes)

The workflow as I see it would be as follows:

- Since I'm working in the Consumer Driven Contract way, in the development mode I'll be working with other people stubs until I'm happy with how their API starts to look like. In this *development mode* I *add* the flag `skip.local.repo` and set it *false*
- Once I've finished working with the local stubs I will set the flag `skip.local.repo` to true to check if the other team has published their stubs. 
- Remember that even if you don't have the internet connection you can set the flag `skip.local.repo` to true since it means that remote repo will ALSO be checked for existence of the artifact. If the connection will fail or timeout or whatever still there is maven repo and grape cache that will work.

@szpak @nurkiewicz @tadaskay @dst  - any objections or whatevers?