### PR TITLE
[#334] Update servlet-api to 3.1.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ buildscript {
     dependencies {
         classpath "org.springframework.boot:spring-boot-gradle-plugin:$springBootVersion"
         classpath 'com.ofg:uptodate-gradle-plugin:+'
-        classpath "com.ofg:micro-common-release:0.1.17"
+        classpath "com.ofg:micro-common-release:0.1.18"
         classpath "io.spring.gradle:dependency-management-plugin:0.2.1.RELEASE"
         if (project.hasProperty("coverage")) { classpath 'org.kt3k.gradle.plugin:coveralls-gradle-plugin:+' }
         if (project.hasProperty("compatibility")) { classpath "be.insaneprogramming.gradle:animalsniffer-gradle-plugin:+" }

--- a/stub-runner/stub-runner/build.gradle
+++ b/stub-runner/stub-runner/build.gradle
@@ -16,7 +16,7 @@ dependencies {
     compile "org.slf4j:log4j-over-slf4j"
     compile 'ch.qos.logback:logback-classic:1.1.2'
     compile 'args4j:args4j:2.0.29'
-    compile 'javax.servlet:javax.servlet-api:3.0.1'
+    compile 'javax.servlet:javax.servlet-api:3.1.0'
     compile 'com.nurkiewicz.asyncretry:asyncretry-jdk7:0.0.6'
 
     testCompile 'org.spockframework:spock-core'


### PR DESCRIPTION
To be compatible with tomcat-embed 8.0.20 used by spring-boot 1.2.2.

Fixes #334
