### PR TITLE
deprecate SwaggerDocumentationConfiguration

### DIFF
--- a/micro-infra-spring/src/main/java/com/ofg/infrastructure/config/EnableMicroserviceDocumentation.java
+++ b/micro-infra-spring/src/main/java/com/ofg/infrastructure/config/EnableMicroserviceDocumentation.java
@@ -1,5 +1,6 @@
 package com.ofg.infrastructure.config;
 
+import com.ofg.infrastructure.web.swagger.SwaggerConfiguration;
 import org.springframework.context.annotation.Import;
 
 import java.lang.annotation.ElementType;
@@ -10,16 +11,11 @@ import java.lang.annotation.Target;
 /**
  * Enables support for Swagger API Documentation.
  *
- * Imports:
- * <ul>
- *  <li>{@link com.ofg.infrastructure.config.SwaggerDocumentationConfiguration} - contains configurations related to Swagger API documentation
- * </ul>
- *
- * @see BaseWebAppConfiguration
+ * @see SwaggerConfiguration
  */
 @Target(ElementType.TYPE)
 @Retention(RetentionPolicy.RUNTIME)
-@Import(SwaggerDocumentationConfiguration.class)
+@Import(SwaggerConfiguration.class)
 public @interface EnableMicroserviceDocumentation {
 
 }

--- a/micro-infra-spring/src/main/java/com/ofg/infrastructure/config/SwaggerDocumentationConfiguration.java
+++ b/micro-infra-spring/src/main/java/com/ofg/infrastructure/config/SwaggerDocumentationConfiguration.java
@@ -13,7 +13,10 @@ import org.springframework.context.annotation.Import;
  * </ul>
  *
  * @see SwaggerConfiguration
+ *
+ * @deprecated since 0.8.18, use SwaggerConfiguration directly
  */
+@Deprecated
 @Configuration
 @Import(SwaggerConfiguration.class)
 public class SwaggerDocumentationConfiguration {


### PR DESCRIPTION
`SwaggerConfiguration` and `@EnableMicroserviceDocumentation` should be enough, imo third way to do the same is not needed.