### PR TITLE
Change released tag format

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,7 +22,10 @@ buildscript {
 apply from: "${rootProject.buildDir}/release/gradle/version.gradle"
 
 scmVersion {
-    tag { prefix = '' }
+    tag {
+        prefix = 'release'
+        versionSeparator = '/'
+    }
 }
 
 allprojects {


### PR DESCRIPTION
To make it easier to distinguish release and not release tags. Useful when manually releasing stub-runner fatjar from CI.