### PR TITLE
remove noverify JVM flag

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -133,8 +133,6 @@ configure(srcSubprojects) {
 
     test {
         jvmArgs project.gradle.startParameter.systemPropertiesArgs.entrySet().collect{"-D${it.key}=${it.value}"}
-        //Workaround for the issue with Java 8u11 and 7u65 - http://www.infoq.com/news/2014/08/Java8-U11-Broke-Tools
-        jvmArgs '-noverify'
         testLogging {
             exceptionFormat = 'full'
         }


### PR DESCRIPTION
Java 8u25 with too strict backward branch verification fix is more than half-year-old