### PR TITLE
[#374] Upgrade to Groovy 2.4.3

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -104,7 +104,7 @@ configure(srcSubprojects) {
 
     dependencyManagement {
         dependencies {
-            "org.codehaus.groovy:groovy-all" "2.4.1"
+            "org.codehaus.groovy:groovy-all" "2.4.3"
             "com.google.guava:guava" "18.0"
             "commons-io:commons-io" "2.4"
 


### PR DESCRIPTION
Groovy 2.4.3 does not like twofold nested classes. Will be reported later as a repression in Groovy.

Fixes #374.