### PR TITLE
Extracting collaborators to allow easier integration in legacy applications

### DIFF
--- a/micro-infra-spring-base/src/main/groovy/com/ofg/infrastructure/healthcheck/CollaboratorsConfiguration.groovy
+++ b/micro-infra-spring-base/src/main/groovy/com/ofg/infrastructure/healthcheck/CollaboratorsConfiguration.groovy
@@ -6,7 +6,6 @@ import groovy.transform.CompileStatic
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
-import org.springframework.context.annotation.Import
 import org.springframework.core.io.Resource
 
 /**
@@ -17,22 +16,16 @@ import org.springframework.core.io.Resource
  */
 @CompileStatic
 @Configuration
-@Import(CollaboratorsConfiguration)
-class HealthCheckConfiguration {
+class CollaboratorsConfiguration {
 
     @Bean
-    PingController pingController() {
-        return new PingController()
+    CollaboratorsStatusResolver collaboratorsStatusResolver(ServiceResolver serviceResolver, PingClient pingClient) {
+        return new CollaboratorsStatusResolver(serviceResolver, pingClient)
     }
 
     @Bean
-    CollaboratorsConnectivityController collaboratorsConnectivityController(CollaboratorsStatusResolver collaboratorsStatusResolver) {
-        return new CollaboratorsConnectivityController(collaboratorsStatusResolver)
-    }
-
-    @Bean
-    MicroserviceConfigurationController microserviceConfigurationController(@Value('${microservice.config.file:classpath:microservice.json}') Resource microserviceConfig) {
-        return new MicroserviceConfigurationController(microserviceConfig)
+    PingClient pingClient(ServiceRestClient serviceRestClient) {
+        return new PingClient(serviceRestClient)
     }
 
 }

--- a/micro-infra-spring-base/src/main/groovy/com/ofg/infrastructure/healthcheck/CollaboratorsConnectivityController.groovy
+++ b/micro-infra-spring-base/src/main/groovy/com/ofg/infrastructure/healthcheck/CollaboratorsConnectivityController.groovy
@@ -16,19 +16,16 @@ import org.springframework.web.bind.annotation.RestController
 /**
  * {@link RestController} providing connection state with services the microservice depends upon.
  */
-@Slf4j
 @RestController
 @CompileStatic
 @PackageScope
 @RequestMapping(value = '/collaborators', method = RequestMethod.GET, produces = MediaType.APPLICATION_JSON_VALUE)
 class CollaboratorsConnectivityController {
 
-    private final ServiceResolver serviceResolver
-    private final PingClient pingClient
+    private final CollaboratorsStatusResolver collaboratorsStatusResolver
 
-    CollaboratorsConnectivityController(ServiceResolver serviceResolver, PingClient pingClient) {
-        this.serviceResolver = serviceResolver
-        this.pingClient = pingClient
+    CollaboratorsConnectivityController(CollaboratorsStatusResolver collaboratorsStatusResolver) {
+        this.collaboratorsStatusResolver = collaboratorsStatusResolver
     }
 
     /**
@@ -39,109 +36,11 @@ class CollaboratorsConnectivityController {
      */
     @RequestMapping
     Map getCollaboratorsConnectivityInfo() {
-        Set<ServicePath> myCollaborators = serviceResolver.fetchMyDependencies()
-        return myCollaborators.collectEntries { ServicePath service ->
-            return [service.path, statusOfAllCollaboratorInstances(service)]
-        }
-    }
-
-    private Map<String, String> statusOfAllCollaboratorInstances(ServicePath service) {
-        Set<URI> allUrisOfService = serviceResolver.fetchAllUris(service)
-        return allUrisOfService.collectEntries { URI instanceUrl ->
-            boolean status = checkConnectionStatus(instanceUrl)
-            return [instanceUrl, CollaboratorStatus.of(status)]
-        }
+        return collaboratorsStatusResolver.statusOfMyCollaborators()
     }
 
     @RequestMapping('/all')
     Map getAllCollaboratorsConnectivityInfo() {
-        final Set<ServicePath> allServices = serviceResolver.fetchAllDependencies()
-        allServices.collectEntries { ServicePath service ->
-            return [service.path, collaboratorsStatusOfAllInstances(service)]
-        }
+        return collaboratorsStatusResolver.statusOfAllDependencies()
     }
-
-    private Map collaboratorsStatusOfAllInstances(ServicePath service) {
-        final Set<URI> collaboratorInstances = serviceResolver.fetchAllUris(service)
-        return collaboratorInstances.collectEntries { URI uri ->
-            [uri, checkCollaborators(uri)]
-        }
-    }
-
-    private Map checkCollaborators(URI url) {
-        Optional<Map> collaborators = establishCollaboratorsStatus(url)
-        return [
-                status: CollaboratorStatus.of(collaborators.isPresent()),
-                collaborators: collaborators.or([:])
-        ]
-    }
-
-    private Optional<Map> establishCollaboratorsStatus(URI url) {
-        Optional<Map> collaborators = tryCallingCollaborators(url)
-        return fallbackWithPingIfCollaboratorsFailed(collaborators, url)
-    }
-
-    Optional<Map> fallbackWithPingIfCollaboratorsFailed(Optional<Map> maybeCollaborators, URI url) {
-        if (maybeCollaborators.isPresent()) {
-            return maybeCollaborators
-        }
-        return checkConnectionStatus(url) ?
-                Optional.of([:]) :
-                Optional.absent()
-    }
-
-    private Optional<Map> tryCallingCollaborators(URI url) {
-        Optional<Map> collaborators = pingClient
-                .checkCollaborators(url)
-                .transform({ tryAdjustLegacyCollaboratorsResponse(it) })
-        return collaborators
-    }
-
-    private Map tryAdjustLegacyCollaboratorsResponse(Map collaboratorsResponse) {
-        if (isLegacyResponse(collaboratorsResponse)) {
-            return adjustLegacyCollaboratorsResponse(collaboratorsResponse)
-        } else {
-            return collaboratorsResponse;
-        }
-    }
-
-    private Map adjustLegacyCollaboratorsResponse(Map collaboratorsResponse) {
-        Map result = [:]
-        collaboratorsResponse.each {alias, statusStr ->
-            tryResolveAlias(alias as String).transform ({ ServicePath path ->
-                result << suspectedStatusOfAllInstances(path, statusStr as String)
-            })
-        }
-        return result
-    }
-
-    private Map suspectedStatusOfAllInstances(ServicePath service, String statusStr) {
-        final Set<URI> allInstances = serviceResolver.fetchAllUris(service)
-        CollaboratorStatus status = CollaboratorStatus.of(statusStr == 'CONNECTED')
-        return [
-                (service.path): allInstances.collectEntries { uri -> [uri, status] }
-        ]
-    }
-
-    private GuavaOptional<ServicePath> tryResolveAlias(String alias) {
-        try {
-            ServiceAlias serviceAlias = new ServiceAlias(alias as String)
-            return GuavaOptional.of(serviceResolver.resolveAlias(serviceAlias))
-        } catch (NoSuchElementException e) {
-            log.warn("Unable to resolve alias $alias", e)
-            return GuavaOptional.absent()
-        }
-    }
-
-    private boolean isLegacyResponse(Map collaboratorsResponse) {
-        return !collaboratorsResponse.empty &&
-                collaboratorsResponse.values().any{!(it instanceof Map)}
-    }
-
-    private boolean checkConnectionStatus(URI url) {
-        final GuavaOptional<String> pingResult = pingClient.ping(url)
-        return pingResult == GuavaOptional.of('OK') ||
-                pingResult == GuavaOptional.of('')
-    }
-
 }

--- a/micro-infra-spring-base/src/main/groovy/com/ofg/infrastructure/healthcheck/CollaboratorsStatusResolver.groovy
+++ b/micro-infra-spring-base/src/main/groovy/com/ofg/infrastructure/healthcheck/CollaboratorsStatusResolver.groovy
@@ -1,0 +1,129 @@
+package com.ofg.infrastructure.healthcheck
+
+import com.google.common.base.Optional
+import com.ofg.infrastructure.discovery.ServiceAlias
+import com.ofg.infrastructure.discovery.ServicePath
+import com.ofg.infrastructure.discovery.ServiceResolver
+import groovy.util.logging.Slf4j
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.stereotype.Component
+
+@Component
+@Slf4j
+class CollaboratorsStatusResolver {
+
+    private final ServiceResolver serviceResolver
+    private final PingClient pingClient
+
+    @Autowired
+    CollaboratorsStatusResolver(ServiceResolver serviceResolver, PingClient pingClient) {
+        this.serviceResolver = serviceResolver
+        this.pingClient = pingClient
+    }
+
+    public Map statusOfMyCollaborators() {
+        Set<ServicePath> myCollaborators = serviceResolver.fetchMyDependencies()
+        return myCollaborators.collectEntries { ServicePath service ->
+            return [service.path, statusOfAllCollaboratorInstances(service)]
+        }
+    }
+
+    public Map statusOfAllDependencies() {
+        final Set<ServicePath> allServices = serviceResolver.fetchAllDependencies()
+        return allServices.collectEntries { ServicePath service ->
+            return [service.path, collaboratorsStatusOfAllInstances(service)]
+        }
+    }
+
+    private Map<String, String> statusOfAllCollaboratorInstances(ServicePath service) {
+        Set<URI> allUrisOfService = serviceResolver.fetchAllUris(service)
+        return allUrisOfService.collectEntries { URI instanceUrl ->
+            boolean status = checkConnectionStatus(instanceUrl)
+            return [instanceUrl, CollaboratorStatus.of(status)]
+        }
+    }
+
+    private Map collaboratorsStatusOfAllInstances(ServicePath service) {
+        final Set<URI> collaboratorInstances = serviceResolver.fetchAllUris(service)
+        return collaboratorInstances.collectEntries { URI uri ->
+            [uri, checkCollaborators(uri)]
+        }
+    }
+
+    private Map checkCollaborators(URI url) {
+        Optional<Map> collaborators = establishCollaboratorsStatus(url)
+        return [
+                status: CollaboratorStatus.of(collaborators.isPresent()),
+                collaborators: collaborators.or([:])
+        ]
+    }
+
+    private Optional<Map> establishCollaboratorsStatus(URI url) {
+        Optional<Map> collaborators = tryCallingCollaborators(url)
+        return fallbackWithPingIfCollaboratorsFailed(collaborators, url)
+    }
+
+    Optional<Map> fallbackWithPingIfCollaboratorsFailed(Optional<Map> maybeCollaborators, URI url) {
+        if (maybeCollaborators.isPresent()) {
+            return maybeCollaborators
+        }
+        return checkConnectionStatus(url) ?
+                Optional.of([:]) :
+                Optional.absent()
+    }
+
+    private Optional<Map> tryCallingCollaborators(URI url) {
+        Optional<Map> collaborators = pingClient
+                .checkCollaborators(url)
+                .transform({ tryAdjustLegacyCollaboratorsResponse(it) })
+        return collaborators
+    }
+
+    private Map tryAdjustLegacyCollaboratorsResponse(Map collaboratorsResponse) {
+        if (isLegacyResponse(collaboratorsResponse)) {
+            return adjustLegacyCollaboratorsResponse(collaboratorsResponse)
+        } else {
+            return collaboratorsResponse;
+        }
+    }
+
+    private Map adjustLegacyCollaboratorsResponse(Map collaboratorsResponse) {
+        Map result = [:]
+        collaboratorsResponse.each {alias, statusStr ->
+            tryResolveAlias(alias as String).transform ({ ServicePath path ->
+                result << suspectedStatusOfAllInstances(path, statusStr as String)
+            })
+        }
+        return result
+    }
+
+    private Map suspectedStatusOfAllInstances(ServicePath service, String statusStr) {
+        final Set<URI> allInstances = serviceResolver.fetchAllUris(service)
+        CollaboratorStatus status = CollaboratorStatus.of(statusStr == 'CONNECTED')
+        return [
+                (service.path): allInstances.collectEntries { uri -> [uri, status] }
+        ]
+    }
+
+    private Optional<ServicePath> tryResolveAlias(String alias) {
+        try {
+            ServiceAlias serviceAlias = new ServiceAlias(alias as String)
+            return Optional.of(serviceResolver.resolveAlias(serviceAlias))
+        } catch (NoSuchElementException e) {
+            log.warn("Unable to resolve alias $alias", e)
+            return Optional.absent()
+        }
+    }
+
+    private boolean isLegacyResponse(Map collaboratorsResponse) {
+        return !collaboratorsResponse.empty &&
+                collaboratorsResponse.values().any{!(it instanceof Map)}
+    }
+
+    private boolean checkConnectionStatus(URI url) {
+        final Optional<String> pingResult = pingClient.ping(url)
+        return pingResult == Optional.of('OK') ||
+                pingResult == Optional.of('')
+    }
+
+}

--- a/micro-infra-spring-base/src/test/groovy/com/ofg/infrastructure/healthcheck/CollaboratorsConnectivityControllerSpec.groovy
+++ b/micro-infra-spring-base/src/test/groovy/com/ofg/infrastructure/healthcheck/CollaboratorsConnectivityControllerSpec.groovy
@@ -23,7 +23,7 @@ class CollaboratorsConnectivityControllerSpec extends Specification {
     def serviceResolverMock = Mock(ServiceResolver)
     def pingClientMock = Mock(PingClient)
 
-    def controller = new CollaboratorsConnectivityController(serviceResolverMock, pingClientMock)
+    def controller = new CollaboratorsConnectivityController(new CollaboratorsStatusResolver(serviceResolverMock, pingClientMock))
 
     def 'should return empty list of collaborators'() {
         given:


### PR DESCRIPTION
This PR is purely extracting of some functionality from `CollaboratorsConnectivityController` into a separate class so that it can be reused without Spring MVC.