### PR TITLE
Choose random port if not set to prevent port clash

### DIFF
--- a/micro-deps/micro-deps-spring-config/src/main/java/com/ofg/infrastructure/discovery/AddressProviderConfiguration.java
+++ b/micro-deps/micro-deps-spring-config/src/main/java/com/ofg/infrastructure/discovery/AddressProviderConfiguration.java
@@ -8,6 +8,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.env.Environment;
+import org.springframework.util.SocketUtils;
 
 import java.net.InetAddress;
 import java.net.UnknownHostException;
@@ -24,10 +25,20 @@ public class AddressProviderConfiguration {
 
     private static final Logger log = LoggerFactory.getLogger(lookup().lookupClass());
 
-    static final Integer DEFAULT_SERVER_PORT = 8080;
-    @Autowired private Environment environment;
+    static final int RANDOM_FREE_PORT = -1;
+    static final int DEFAULT_SERVER_PORT = RANDOM_FREE_PORT;
 
-    @Bean MicroserviceAddressProvider microserviceAddressProvider(@Value("${microservice.host:#{T(com.ofg.infrastructure.discovery.AddressProviderConfiguration).resolveMicroserviceLocalhost()}}") String microserviceHost, @Value("${microservice.port:#{T(com.ofg.infrastructure.discovery.AddressProviderConfiguration).resolveMicroservicePort(@environment)}}") int microservicePort) {
+    @Autowired
+    private Environment environment;
+
+    @Bean
+    public MicroserviceAddressProvider microserviceAddressProvider(
+            @Value("${microservice.host:#{T(com.ofg.infrastructure.discovery.AddressProviderConfiguration).resolveMicroserviceLocalhost()}}") String microserviceHost,
+            @Value("${microservice.port:#{T(com.ofg.infrastructure.discovery.AddressProviderConfiguration).resolveMicroservicePort(@environment)}}") int microservicePort) {
+        if (microservicePort == RANDOM_FREE_PORT) {
+            microservicePort = SocketUtils.findAvailableTcpPort();
+            log.info("Microservice available port: {}", microservicePort);
+        }
         return new MicroserviceAddressProvider(microserviceHost, microservicePort);
     }
 

--- a/micro-deps/micro-deps-spring-config/src/test/groovy/com/ofg/infrastructure/discovery/ServiceResolverConfigurationSpec.groovy
+++ b/micro-deps/micro-deps-spring-config/src/test/groovy/com/ofg/infrastructure/discovery/ServiceResolverConfigurationSpec.groovy
@@ -33,13 +33,13 @@ class ServiceResolverConfigurationSpec extends Specification {
             System.setProperty('port', previousProp ?: '')
     }
     
-    def "should resolve microservice port to default value when there is no system prop nor environment prop"() {
+    def "should resolve microservice port to random value greater than 1024 when there is no system prop nor environment prop"() {
         given:
             String previousProp = System.setProperty('port', '')
         when:
             ApplicationContext applicationContext = new AnnotationConfigApplicationContext(PropertySourceConfiguration, AddressProviderConfiguration)
         then:
-            applicationContext.getBean(MicroserviceAddressProvider).port == 8080
+            applicationContext.getBean(MicroserviceAddressProvider).port > 1024
         cleanup:
             System.setProperty('port', previousProp ?: '')
     }    


### PR DESCRIPTION
We should not use default port because it will clash with port that was already bind or with other instance during build on build server