### PR TITLE
Provider strategies should not be constant

### DIFF
--- a/micro-deps/micro-deps/src/main/java/com/ofg/infrastructure/discovery/util/ProviderStrategyFactory.java
+++ b/micro-deps/micro-deps/src/main/java/com/ofg/infrastructure/discovery/util/ProviderStrategyFactory.java
@@ -1,26 +1,23 @@
 package com.ofg.infrastructure.discovery.util;
 
-import com.google.common.collect.ImmutableMap;
 import org.apache.curator.x.discovery.ProviderStrategy;
 import org.apache.curator.x.discovery.strategies.RandomStrategy;
 import org.apache.curator.x.discovery.strategies.RoundRobinStrategy;
 import org.apache.curator.x.discovery.strategies.StickyStrategy;
 
-import java.util.Map;
-
 public class ProviderStrategyFactory {
 
-    private static final Map<LoadBalancerType, ProviderStrategy> STRATEGY_CREATORS =
-            ImmutableMap.<LoadBalancerType, ProviderStrategy>builder()
-                    .put(LoadBalancerType.STICKY, new StickyStrategy<>(new RoundRobinStrategy()))
-                    .put(LoadBalancerType.RANDOM, new RandomStrategy<>())
-                    .put(LoadBalancerType.ROUND_ROBIN, new RoundRobinStrategy<>())
-                    .build();
-
-
     public ProviderStrategy createProviderStrategy(LoadBalancerType type) {
-        return STRATEGY_CREATORS.get(type);
+        switch (type) {
+            case ROUND_ROBIN:
+                return new RoundRobinStrategy<>();
+            case RANDOM:
+                return new RandomStrategy<>();
+            case STICKY:
+                return new StickyStrategy<>(new RoundRobinStrategy<>());
+            default:
+                throw new IllegalArgumentException("Unknown load balancer type " + type);
+        }
     }
-
 }
 


### PR DESCRIPTION
because they are stateful, e.g.: `private final AtomicReference<ServiceInstance<T>>   ourInstance = new AtomicReference<ServiceInstance<T>>(null);`