### PR TITLE
[#313] Add Sonarqube plugin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,13 +5,17 @@ buildscript {
     repositories {
         mavenLocal()
         jcenter()
+        maven { url "https://plugins.gradle.org/m2/" }  //for sonarqube plugin
     }
     dependencies {
         classpath "org.springframework.boot:spring-boot-gradle-plugin:$springBootVersion"
         classpath 'com.ofg:uptodate-gradle-plugin:+'
         classpath "com.ofg:micro-common-release:0.1.18"
         classpath "io.spring.gradle:dependency-management-plugin:0.2.1.RELEASE"
-        if (project.hasProperty("coverage")) { classpath 'org.kt3k.gradle.plugin:coveralls-gradle-plugin:+' }
+        if (project.hasProperty("coverage")) {
+            classpath 'org.kt3k.gradle.plugin:coveralls-gradle-plugin:+'
+            classpath "org.sonarqube.gradle:gradle-sonarqube-plugin:1.0"
+        }
         if (project.hasProperty("compatibility")) { classpath "be.insaneprogramming.gradle:animalsniffer-gradle-plugin:+" }
     }
     dependencies {
@@ -33,7 +37,7 @@ allprojects {
     project.version = scmVersion.version
 }
 
-Set emptySubprojects = [project(':swagger'), project(':micro-deps'), project(':stub-runner')]
+Set emptySubprojects = [project(':swagger'), project(':micro-deps-root'), project(':stub-runner-root')]
 Set srcSubprojects = subprojects - emptySubprojects
 
 configure(srcSubprojects) {
@@ -180,6 +184,9 @@ if (project.hasProperty("coverage")) {
         }
     }
 
+    apply plugin: 'com.github.kt3k.coveralls'
+    apply plugin: 'org.sonarqube'
+
     configure(srcSubprojects) {
         jacocoTestReport {
             reports {
@@ -192,9 +199,13 @@ if (project.hasProperty("coverage")) {
                 excludes = ['*Configuration']
             }
         }
-    }
 
-    apply plugin: 'com.github.kt3k.coveralls'
+        sonarqube {
+            properties {
+                property "sonar.groovy.jacoco.reportPath", "$buildDir/jacoco/test.exec"     //TODO: Could be taken from JaCoCo extension directly
+            }
+        }
+    }
 
     coveralls {
         sourceDirs = files(srcSubprojects.sourceSets.main.allSource.srcDirs).files.absolutePath

--- a/build.gradle
+++ b/build.gradle
@@ -187,6 +187,12 @@ if (project.hasProperty("coverage")) {
     apply plugin: 'com.github.kt3k.coveralls'
     apply plugin: 'org.sonarqube'
 
+    sonarqube {
+        properties {
+            property "sonar.projectName", "micro-infra-spring"
+        }
+    }
+
     configure(srcSubprojects) {
         jacocoTestReport {
             reports {

--- a/micro-deps/build.gradle
+++ b/micro-deps/build.gradle
@@ -6,7 +6,7 @@ subprojects {
     }
 }
 
-project(':micro-deps:micro-deps') {
+project(':micro-deps-root:micro-deps') {
     description = 'Microservice dependency manager'
 
     dependencies {
@@ -22,15 +22,15 @@ project(':micro-deps:micro-deps') {
     }
 }
 
-project(':micro-deps:micro-deps-spring-config') {
+project(':micro-deps-root:micro-deps-spring-config') {
     description = 'Microservice dependency manager - default Spring configuration'
 
     sourceSets.main.java.srcDirs = []
     sourceSets.main.groovy.srcDirs += ["src/main/java", "src/main/groovy"]
 
     dependencies {
-        compile project(':micro-deps:micro-deps')
-        compile(project(':stub-runner:stub-runner-spring')) {
+        compile project(':micro-deps-root:micro-deps')
+        compile(project(':stub-runner-root:stub-runner-spring')) {
             exclude group: "org.slf4j", module: "log4j-over-slf4j"
         }
         compile "org.springframework:spring-context"
@@ -45,14 +45,14 @@ project(':micro-deps:micro-deps-spring-config') {
     }
 }
 
-project(':micro-deps:micro-deps-spring-test-config') {
+project(':micro-deps-root:micro-deps-spring-test-config') {
     description = 'Microservice dependency manager - Spring test configuration'
 
     ext {
         spock07Version = "0.7-groovy-2.0"
     }
     dependencies {
-        compile project(':micro-deps:micro-deps-spring-config')
+        compile project(':micro-deps-root:micro-deps-spring-config')
         compile 'org.codehaus.groovy:groovy-all'
         compile 'cglib:cglib-nodep:3.1'
         compile 'org.objenesis:objenesis:2.1'

--- a/micro-infra-spring-base/build.gradle
+++ b/micro-infra-spring-base/build.gradle
@@ -10,7 +10,7 @@ sourceSets.main.java.srcDirs = []
 sourceSets.main.groovy.srcDirs += ["src/main/java", "src/main/groovy"]
 
 dependencies {
-    compile project(":micro-deps:micro-deps-spring-config")
+    compile project(":micro-deps-root:micro-deps-spring-config")
 
     compile "org.codehaus.groovy:groovy-all"
     compile 'com.fasterxml.jackson.core:jackson-databind'

--- a/micro-infra-spring-config/build.gradle
+++ b/micro-infra-spring-config/build.gradle
@@ -9,7 +9,7 @@ sourceSets.main.java.srcDirs = []
 sourceSets.main.groovy.srcDirs += ["src/main/java", "src/main/groovy"]
 
 dependencies {
-    compile project(':micro-deps:micro-deps')
+    compile project(':micro-deps-root:micro-deps')
 
     compile("org.springframework.cloud:spring-cloud-config-client:$springCloudVersion") {
         exclude group: 'ch.qos.logback', module: 'logback-classic'

--- a/micro-infra-spring-test/build.gradle
+++ b/micro-infra-spring-test/build.gradle
@@ -1,5 +1,5 @@
 description = 'Microservice testing utilities'
 
 dependencies {
-    compile project(":micro-deps:micro-deps-spring-test-config")
+    compile project(":micro-deps-root:micro-deps-spring-test-config")
 }

--- a/settings.gradle
+++ b/settings.gradle
@@ -14,3 +14,7 @@ include ':micro-deps:micro-deps-spring-config'
 include ':micro-deps:micro-deps-spring-test-config'
 
 rootProject.name = 'micro-infra-spring-root'
+
+//to prevent StackOverflow in Sonar
+project(":micro-deps").name = "micro-deps-root"
+project(":stub-runner").name = "stub-runner-root"

--- a/stub-runner/stub-runner-spring/build.gradle
+++ b/stub-runner/stub-runner-spring/build.gradle
@@ -1,8 +1,8 @@
 description = 'Spring configuration for stub-runner'
 
 dependencies {
-    compile project(':micro-deps:micro-deps')
-    compile project(':stub-runner:stub-runner')
+    compile project(':micro-deps-root:micro-deps')
+    compile project(':stub-runner-root:stub-runner')
 
     compile 'org.codehaus.groovy:groovy-all'
     compile 'org.springframework:spring-context'

--- a/stub-runner/stub-runner/README.md
+++ b/stub-runner/stub-runner/README.md
@@ -92,13 +92,13 @@ after switching it on stub-runner will wait default 30 second for service regist
 You can configure the stub runner by either passing the full arguments list with the `-Pargs` like this:
 
 ```
-./gradlew stub-runner:stub-runner:run -Pargs="-c pl -minp 10000 -maxp 10005 -n com/ofg/twitter-places-analyzer -sr http://dl.bintray.com/4finance/micro -zl localhost:2181 -s"
+./gradlew stub-runner-root:stub-runner:run -Pargs="-c pl -minp 10000 -maxp 10005 -n com/ofg/twitter-places-analyzer -sr http://dl.bintray.com/4finance/micro -zl localhost:2181 -s"
 ```
 
 or each parameter separately with a `-P` prefix and without the hyphen `-` in the name of the param
 
 ```
-./gradlew stub-runner:stub-runner:run -Pc=pl -Pminp=10000 -Pmaxp=10005 -Pn=com/ofg/twitter-places-analyzer -Psr=http://dl.bintray.com/4finance/micro -Pzl=localhost:2181 -Ps
+./gradlew stub-runner-root:stub-runner:run -Pc=pl -Pminp=10000 -Pmaxp=10005 -Pn=com/ofg/twitter-places-analyzer -Psr=http://dl.bintray.com/4finance/micro -Pzl=localhost:2181 -Ps
 ```
 
 ### Defining collaborators' stubs

--- a/stub-runner/stub-runner/build.gradle
+++ b/stub-runner/stub-runner/build.gradle
@@ -3,7 +3,7 @@ description = 'Runs stubs for service collaborators'
 apply plugin: 'application'
 
 dependencies {
-    compile project(':micro-deps:micro-deps')
+    compile project(':micro-deps-root:micro-deps')
     compile 'org.apache.ivy:ivy:2.4.0'
     compile 'org.codehaus.groovy:groovy-all'
     compile('com.github.tomakehurst:wiremock') {


### PR DESCRIPTION
By the way duplicated module names were changed to prevent StackOverflowException in Sonar.

It will be required to adjust all scripts/jobs/etc. which call stub-runner or micro-deps tasks directly. 