### PR TITLE
Broken condition when filtering out static resource for correlation ID generation

### DIFF
--- a/micro-infra-spring-base/src/main/groovy/com/ofg/infrastructure/web/correlationid/CorrelationIdConfiguration.java
+++ b/micro-infra-spring-base/src/main/groovy/com/ofg/infrastructure/web/correlationid/CorrelationIdConfiguration.java
@@ -28,7 +28,7 @@ public class CorrelationIdConfiguration {
 
     @Bean
     public FilterRegistrationBean correlationHeaderFilter(UuidGenerator uuidGenerator) {
-        Pattern pattern = StringUtils.isBlank(skipPattern) ? Pattern.compile(skipPattern) : CorrelationIdFilter.DEFAULT_SKIP_PATTERN;
+        Pattern pattern = StringUtils.isNotBlank(skipPattern) ? Pattern.compile(skipPattern) : CorrelationIdFilter.DEFAULT_SKIP_PATTERN;
         return new FilterRegistrationBean(new CorrelationIdFilter(uuidGenerator, pattern));
     }
 


### PR DESCRIPTION
Was fixed in https://github.com/4finance/micro-infra-spring/commit/e403c7e390c6c65646cb3ed8dfd23b2968115e8a but broken again in https://github.com/4finance/micro-infra-spring/commit/0ec2c3fc273c454d00be9bc574019dcbcd5ac537