### PR TITLE
added maven central for repos

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -60,6 +60,7 @@ apply from: "${rootProject.buildDir}/release/gradle/release.gradle"
 allprojects {
     repositories {
         mavenLocal()
+        mavenCentral()
         jcenter()
     }
 


### PR DESCRIPTION
Could not resolve all dependencies for configuration ':micro-infra-spring-reactor:compile'.
> Could not find org.projectreactor:reactor-spring:1.0.1.RELEASE.
  Searched in the following locations:
      file:/root/.m2/repository/org/projectreactor/reactor-spring/1.0.1.RELEASE/reactor-spring-1.0.1.RELEASE.pom
      file:/root/.m2/repository/org/projectreactor/reactor-spring/1.0.1.RELEASE/reactor-spring-1.0.1.RELEASE.jar
      https://jcenter.bintray.com/org/projectreactor/reactor-spring/1.0.1.RELEASE/reactor-spring-1.0.1.RELEASE.pom
      https://jcenter.bintray.com/org/projectreactor/reactor-spring/1.0.1.RELEASE/reactor-spring-1.0.1.RELEASE.jar
  Required by:
      com.ofg:micro-infra-spring-reactor:0.9.1