### PR TITLE
Better http query parameters according to discussion on issue #469 

### DIFF
--- a/micro-infra-spring-base/src/main/groovy/com/ofg/infrastructure/web/resttemplate/fluent/common/response/executor/ResponseTypeRelatedRequestsExecutor.groovy
+++ b/micro-infra-spring-base/src/main/groovy/com/ofg/infrastructure/web/resttemplate/fluent/common/response/executor/ResponseTypeRelatedRequestsExecutor.groovy
@@ -4,11 +4,8 @@ import com.google.common.util.concurrent.ListenableFuture
 import com.nurkiewicz.asyncretry.RetryExecutor
 import groovy.transform.TypeChecked
 import org.springframework.http.HttpMethod
-import org.springframework.http.HttpMethod as SpringHttpMethod
 import org.springframework.http.ResponseEntity
 import org.springframework.web.client.RestOperations
-
-import static org.springframework.http.HttpMethod.DELETE
 
 /**
  * Abstraction over {@link RestOperations} that for a {@link ResponseTypeRelatedRequestsExecutor#getHttpMethod()} 
@@ -38,6 +35,7 @@ public class ResponseTypeRelatedRequestsExecutor<T> {
         this.responseType = responseType
         this.restExecutor = new RestExecutor(restOperations, retryExecutor)
         this.httpMethod = httpMethod
+        params.url = params?.urlWithQueryParameters?params.urlWithQueryParameters:params.url
     }
 
     ResponseEntity<T> exchange() {

--- a/micro-infra-spring-base/src/main/groovy/com/ofg/infrastructure/web/resttemplate/fluent/common/response/receive/BodyContainingWithQueryParameters.groovy
+++ b/micro-infra-spring-base/src/main/groovy/com/ofg/infrastructure/web/resttemplate/fluent/common/response/receive/BodyContainingWithQueryParameters.groovy
@@ -1,0 +1,7 @@
+package com.ofg.infrastructure.web.resttemplate.fluent.common.response.receive
+
+class BodyContainingWithQueryParameters<T> extends WithQueryParameters<T> {
+    BodyContainingWithQueryParameters(T parent, Map<String, Object> params) {
+        super(parent, params)
+    }
+}

--- a/micro-infra-spring-base/src/main/groovy/com/ofg/infrastructure/web/resttemplate/fluent/common/response/receive/BodylessWithQueryParameters.groovy
+++ b/micro-infra-spring-base/src/main/groovy/com/ofg/infrastructure/web/resttemplate/fluent/common/response/receive/BodylessWithQueryParameters.groovy
@@ -1,0 +1,10 @@
+package com.ofg.infrastructure.web.resttemplate.fluent.common.response.receive
+
+import groovy.transform.CompileStatic
+
+@CompileStatic
+class BodylessWithQueryParameters<T> extends WithQueryParameters<T> {
+    BodylessWithQueryParameters(T parent, Map<String,Object> params) {
+        super(parent, params)
+    }
+}

--- a/micro-infra-spring-base/src/main/groovy/com/ofg/infrastructure/web/resttemplate/fluent/common/response/receive/ParametersHaving.java
+++ b/micro-infra-spring-base/src/main/groovy/com/ofg/infrastructure/web/resttemplate/fluent/common/response/receive/ParametersHaving.java
@@ -1,0 +1,5 @@
+package com.ofg.infrastructure.web.resttemplate.fluent.common.response.receive;
+
+public interface ParametersHaving<T> {
+    ParametersSetting<T> withQueryParameters();
+}

--- a/micro-infra-spring-base/src/main/groovy/com/ofg/infrastructure/web/resttemplate/fluent/common/response/receive/ParametersHaving.java
+++ b/micro-infra-spring-base/src/main/groovy/com/ofg/infrastructure/web/resttemplate/fluent/common/response/receive/ParametersHaving.java
@@ -1,5 +1,0 @@
-package com.ofg.infrastructure.web.resttemplate.fluent.common.response.receive;
-
-public interface ParametersHaving<T> {
-    ParametersSetting<T> withQueryParameters();
-}

--- a/micro-infra-spring-base/src/main/groovy/com/ofg/infrastructure/web/resttemplate/fluent/common/response/receive/QueryParametersHaving.java
+++ b/micro-infra-spring-base/src/main/groovy/com/ofg/infrastructure/web/resttemplate/fluent/common/response/receive/QueryParametersHaving.java
@@ -1,0 +1,8 @@
+package com.ofg.infrastructure.web.resttemplate.fluent.common.response.receive;
+
+/**
+ * Interface for HttpMethods that can have query parameters set on its requests
+ */
+public interface QueryParametersHaving<T> {
+    QueryParametersSetting<T> withQueryParameters();
+}

--- a/micro-infra-spring-base/src/main/groovy/com/ofg/infrastructure/web/resttemplate/fluent/common/response/receive/ResponseReceiving.groovy
+++ b/micro-infra-spring-base/src/main/groovy/com/ofg/infrastructure/web/resttemplate/fluent/common/response/receive/ResponseReceiving.groovy
@@ -4,6 +4,6 @@ import com.ofg.infrastructure.web.resttemplate.fluent.common.response.executor.E
 /**
  * Interface that is a base for all the HttpMethods
  */
-interface ResponseReceiving<T> extends HeadersHaving<T>, Executable<T>, ResponseExtracting {
+interface ResponseReceiving<T> extends HeadersHaving<T>, QueryParametersHaving<T>, Executable<T>, ResponseExtracting {
     
 }

--- a/micro-infra-spring-base/src/main/groovy/com/ofg/infrastructure/web/resttemplate/fluent/delete/DeleteMethodBuilder.groovy
+++ b/micro-infra-spring-base/src/main/groovy/com/ofg/infrastructure/web/resttemplate/fluent/delete/DeleteMethodBuilder.groovy
@@ -13,6 +13,9 @@ import com.ofg.infrastructure.web.resttemplate.fluent.common.response.executor.R
 import com.ofg.infrastructure.web.resttemplate.fluent.common.response.receive.BodylessWithHeaders
 import com.ofg.infrastructure.web.resttemplate.fluent.common.response.receive.HeadersSetting
 import com.ofg.infrastructure.web.resttemplate.fluent.common.response.receive.PredefinedHttpHeaders
+import com.ofg.infrastructure.web.resttemplate.fluent.common.response.receive.QueryParametersHaving
+import com.ofg.infrastructure.web.resttemplate.fluent.common.response.receive.QueryParametersSetting
+import com.ofg.infrastructure.web.resttemplate.fluent.common.response.receive.BodylessWithQueryParameters
 import groovy.transform.TypeChecked
 import org.springframework.http.HttpEntity
 import org.springframework.http.HttpMethod

--- a/micro-infra-spring-base/src/main/groovy/com/ofg/infrastructure/web/resttemplate/fluent/delete/DeleteMethodBuilder.groovy
+++ b/micro-infra-spring-base/src/main/groovy/com/ofg/infrastructure/web/resttemplate/fluent/delete/DeleteMethodBuilder.groovy
@@ -27,17 +27,20 @@ import static com.ofg.infrastructure.web.resttemplate.fluent.common.response.rec
  * Implementation of the {@link org.springframework.http.HttpMethod#DELETE method} fluent API
  */
 @TypeChecked
-class DeleteMethodBuilder extends AbstractMethodBuilder implements DeleteMethod, UrlParameterizableDeleteMethod, ResponseReceivingDeleteMethod {
+class DeleteMethodBuilder extends AbstractMethodBuilder implements DeleteMethod, UrlParameterizableDeleteMethod,
+        ResponseReceivingDeleteMethod, QueryParametersHaving<ResponseReceivingDeleteMethod> {
 
 
     private final RestOperations restOperations
     private final RetryExecutor retryExecutor
     private final BodylessWithHeaders<ResponseReceivingDeleteMethod> withHeaders
+    private final BodylessWithQueryParameters<ResponseReceivingDeleteMethod> withQueryParameters
 
     DeleteMethodBuilder(Callable<String> host, RestOperations restOperations, PredefinedHttpHeaders predefinedHeaders, RetryExecutor retryExecutor) {
         this.restOperations = restOperations
         params.host = host
         withHeaders =  new BodylessWithHeaders<ResponseReceivingDeleteMethod>(this, params, predefinedHeaders)
+        withQueryParameters = new BodylessWithQueryParameters<ResponseReceivingDeleteMethod>(this, params)
         this.retryExecutor = retryExecutor
     }
 
@@ -132,5 +135,10 @@ class DeleteMethodBuilder extends AbstractMethodBuilder implements DeleteMethod,
     @Override
     HeadersSetting<ResponseReceivingDeleteMethod> withHeaders() {
         return withHeaders.withHeaders()
+    }
+
+    @Override
+    QueryParametersSetting<ResponseReceivingDeleteMethod> withQueryParameters() {
+        return withQueryParameters.withQueryParameters()
     }
 }

--- a/micro-infra-spring-base/src/main/groovy/com/ofg/infrastructure/web/resttemplate/fluent/get/GetMethodBuilder.groovy
+++ b/micro-infra-spring-base/src/main/groovy/com/ofg/infrastructure/web/resttemplate/fluent/get/GetMethodBuilder.groovy
@@ -25,11 +25,14 @@ import static com.ofg.infrastructure.web.resttemplate.fluent.common.response.rec
  * Implementation of the {@link org.springframework.http.HttpMethod#GET method} fluent API
  */
 @TypeChecked
-class GetMethodBuilder extends AbstractMethodBuilder implements GetMethod, UrlParameterizableGetMethod, ResponseReceivingGetMethod, HeadersHaving<ResponseReceivingGetMethod>, ParametersHaving<ResponseReceivingGetMethod> {
+class GetMethodBuilder extends AbstractMethodBuilder implements GetMethod, UrlParameterizableGetMethod, ResponseReceivingGetMethod,
+        HeadersHaving<ResponseReceivingGetMethod>,
+        QueryParametersHaving<ResponseReceivingGetMethod> {
 
     private final RestOperations restOperations
     private final RetryExecutor retryExecutor
     private final BodyContainingWithHeaders<ResponseReceivingGetMethod> withHeaders
+    private final BodyContainingWithQueryParameters<ResponseReceivingGetMethod> withQueryParameters
 
     GetMethodBuilder(RestOperations restOperations) {
         this(EMPTY_HOST, restOperations, NO_PREDEFINED_HEADERS, SyncRetryExecutor.INSTANCE)
@@ -39,6 +42,7 @@ class GetMethodBuilder extends AbstractMethodBuilder implements GetMethod, UrlPa
         this.restOperations = restOperations
         params.host = host
         withHeaders = new BodyContainingWithHeaders<ResponseReceivingGetMethod>(this, params, predefinedHeaders)
+        withQueryParameters = new BodyContainingWithQueryParameters<ResponseReceivingGetMethod>(this, params)
         this.retryExecutor = retryExecutor
     }
 
@@ -47,7 +51,7 @@ class GetMethodBuilder extends AbstractMethodBuilder implements GetMethod, UrlPa
         params.url = url
         return this
     }
-    
+
     @Override
     ResponseReceivingGetMethod onUrl(String url) {
         params.url = new URI(url)
@@ -75,7 +79,7 @@ class GetMethodBuilder extends AbstractMethodBuilder implements GetMethod, UrlPa
     @Override
     ResponseReceivingGetMethod withVariables(Object... urlVariables) {
         params.urlVariablesArray = urlVariables
-        if(templateStartsWithPlaceholder()) {
+        if (templateStartsWithPlaceholder()) {
             replaceFirstPlaceholderWithValue()
         }
         return this
@@ -133,7 +137,7 @@ class GetMethodBuilder extends AbstractMethodBuilder implements GetMethod, UrlPa
     @Override
     ListenableFuture<Void> ignoringResponseAsync() {
         ListenableFuture<ResponseEntity<Object>> future = aResponseEntity().ofTypeAsync(Object)
-        return Futures.transform(future, {ResponseEntity r -> null as Void} as Function<ResponseEntity, Void>)
+        return Futures.transform(future, { ResponseEntity r -> null as Void } as Function<ResponseEntity, Void>)
     }
 
     com.ofg.infrastructure.web.resttemplate.fluent.common.request.HttpMethod<ResponseReceivingGetMethod, UrlParameterizableGetMethod> withCircuitBreaker(HystrixCommand.Setter setter) {
@@ -154,7 +158,7 @@ class GetMethodBuilder extends AbstractMethodBuilder implements GetMethod, UrlPa
     }
 
     @Override
-    ParametersSetting<ResponseReceivingGetMethod> withQueryParameters() {
+    QueryParametersSetting<ResponseReceivingGetMethod> withQueryParameters() {
         return withQueryParameters.withQueryParameters()
     }
 

--- a/micro-infra-spring-base/src/main/groovy/com/ofg/infrastructure/web/resttemplate/fluent/get/GetMethodBuilder.groovy
+++ b/micro-infra-spring-base/src/main/groovy/com/ofg/infrastructure/web/resttemplate/fluent/get/GetMethodBuilder.groovy
@@ -1,4 +1,5 @@
 package com.ofg.infrastructure.web.resttemplate.fluent.get
+
 import com.google.common.base.Function
 import com.google.common.util.concurrent.Futures
 import com.google.common.util.concurrent.ListenableFuture
@@ -8,12 +9,7 @@ import com.nurkiewicz.asyncretry.SyncRetryExecutor
 import com.ofg.infrastructure.web.resttemplate.fluent.AbstractMethodBuilder
 import com.ofg.infrastructure.web.resttemplate.fluent.UrlUtils
 import com.ofg.infrastructure.web.resttemplate.fluent.common.response.executor.ResponseTypeRelatedRequestsExecutor
-import com.ofg.infrastructure.web.resttemplate.fluent.common.response.receive.BodyContainingWithHeaders
-import com.ofg.infrastructure.web.resttemplate.fluent.common.response.receive.HeadersHaving
-import com.ofg.infrastructure.web.resttemplate.fluent.common.response.receive.HeadersSetting
-import com.ofg.infrastructure.web.resttemplate.fluent.common.response.receive.ObjectReceiving
-import com.ofg.infrastructure.web.resttemplate.fluent.common.response.receive.PredefinedHttpHeaders
-import com.ofg.infrastructure.web.resttemplate.fluent.common.response.receive.ResponseEntityReceiving
+import com.ofg.infrastructure.web.resttemplate.fluent.common.response.receive.*
 import groovy.transform.TypeChecked
 import org.springframework.http.HttpEntity
 import org.springframework.http.HttpMethod
@@ -24,11 +20,12 @@ import java.util.concurrent.Callable
 
 import static com.ofg.infrastructure.web.resttemplate.fluent.HttpMethodBuilder.EMPTY_HOST
 import static com.ofg.infrastructure.web.resttemplate.fluent.common.response.receive.PredefinedHttpHeaders.NO_PREDEFINED_HEADERS
+
 /**
  * Implementation of the {@link org.springframework.http.HttpMethod#GET method} fluent API
  */
 @TypeChecked
-class GetMethodBuilder extends AbstractMethodBuilder implements GetMethod, UrlParameterizableGetMethod, ResponseReceivingGetMethod, HeadersHaving<ResponseReceivingGetMethod> {
+class GetMethodBuilder extends AbstractMethodBuilder implements GetMethod, UrlParameterizableGetMethod, ResponseReceivingGetMethod, HeadersHaving<ResponseReceivingGetMethod>, ParametersHaving<ResponseReceivingGetMethod> {
 
     private final RestOperations restOperations
     private final RetryExecutor retryExecutor
@@ -154,6 +151,11 @@ class GetMethodBuilder extends AbstractMethodBuilder implements GetMethod, UrlPa
     @Override
     HeadersSetting<ResponseReceivingGetMethod> withHeaders() {
         return withHeaders.withHeaders()
+    }
+
+    @Override
+    ParametersSetting<ResponseReceivingGetMethod> withQueryParameters() {
+        return withQueryParameters.withQueryParameters()
     }
 
     @Override

--- a/micro-infra-spring-base/src/main/groovy/com/ofg/infrastructure/web/resttemplate/fluent/head/HeadMethodBuilder.groovy
+++ b/micro-infra-spring-base/src/main/groovy/com/ofg/infrastructure/web/resttemplate/fluent/head/HeadMethodBuilder.groovy
@@ -9,8 +9,11 @@ import com.nurkiewicz.asyncretry.SyncRetryExecutor
 import com.ofg.infrastructure.web.resttemplate.fluent.UrlUtils
 import com.ofg.infrastructure.web.resttemplate.fluent.common.response.executor.ResponseTypeRelatedRequestsExecutor
 import com.ofg.infrastructure.web.resttemplate.fluent.common.response.receive.BodylessWithHeaders
+import com.ofg.infrastructure.web.resttemplate.fluent.common.response.receive.BodylessWithQueryParameters
 import com.ofg.infrastructure.web.resttemplate.fluent.common.response.receive.HeadersSetting
 import com.ofg.infrastructure.web.resttemplate.fluent.common.response.receive.PredefinedHttpHeaders
+import com.ofg.infrastructure.web.resttemplate.fluent.common.response.receive.QueryParametersHaving
+import com.ofg.infrastructure.web.resttemplate.fluent.common.response.receive.QueryParametersSetting
 import groovy.transform.TypeChecked
 import org.springframework.http.HttpEntity
 import org.springframework.http.HttpHeaders
@@ -22,22 +25,24 @@ import java.util.concurrent.Callable
 
 import static com.ofg.infrastructure.web.resttemplate.fluent.HttpMethodBuilder.EMPTY_HOST
 import static com.ofg.infrastructure.web.resttemplate.fluent.common.response.receive.PredefinedHttpHeaders.NO_PREDEFINED_HEADERS
-
 /**
  * Implementation of the {@link org.springframework.http.HttpMethod#HEAD method} fluent API
  */
 @TypeChecked
-class HeadMethodBuilder implements HeadMethod, UrlParameterizableHeadMethod, ResponseReceivingHeadMethod {
+class HeadMethodBuilder implements HeadMethod, UrlParameterizableHeadMethod, ResponseReceivingHeadMethod,
+        QueryParametersHaving<ResponseReceivingHeadMethod> {
 
     private final Map params = [:]
     private final RestOperations restOperations
     private final RetryExecutor retryExecutor
     private final BodylessWithHeaders<ResponseReceivingHeadMethod> withHeaders
+    private final BodylessWithQueryParameters<ResponseReceivingHeadMethod> withQueryParameters
 
     HeadMethodBuilder(Callable<String> host, RestOperations restOperations, PredefinedHttpHeaders predefinedHeaders, RetryExecutor retryExecutor) {
         this.restOperations = restOperations
         params.host = host
         withHeaders =  new BodylessWithHeaders<ResponseReceivingHeadMethod>(this, params, predefinedHeaders)
+        withQueryParameters = new BodylessWithQueryParameters<ResponseReceivingHeadMethod>(this, params)
         this.retryExecutor = retryExecutor
     }
 
@@ -141,5 +146,10 @@ class HeadMethodBuilder implements HeadMethod, UrlParameterizableHeadMethod, Res
     @Override
     HeadersSetting<ResponseReceivingHeadMethod> withHeaders() {
         return withHeaders.withHeaders()
+    }
+
+    @Override
+    QueryParametersSetting<ResponseReceivingHeadMethod> withQueryParameters() {
+        return withQueryParameters.withQueryParameters()
     }
 }

--- a/micro-infra-spring-base/src/main/groovy/com/ofg/infrastructure/web/resttemplate/fluent/options/OptionsMethodBuilder.groovy
+++ b/micro-infra-spring-base/src/main/groovy/com/ofg/infrastructure/web/resttemplate/fluent/options/OptionsMethodBuilder.groovy
@@ -9,10 +9,7 @@ import com.nurkiewicz.asyncretry.SyncRetryExecutor
 import com.ofg.infrastructure.web.resttemplate.fluent.HttpMethodBuilder
 import com.ofg.infrastructure.web.resttemplate.fluent.UrlUtils
 import com.ofg.infrastructure.web.resttemplate.fluent.common.response.executor.ResponseTypeRelatedRequestsExecutor
-import com.ofg.infrastructure.web.resttemplate.fluent.common.response.receive.HeadersSetting
-import com.ofg.infrastructure.web.resttemplate.fluent.common.response.receive.ObjectReceiving
-import com.ofg.infrastructure.web.resttemplate.fluent.common.response.receive.PredefinedHttpHeaders
-import com.ofg.infrastructure.web.resttemplate.fluent.common.response.receive.ResponseEntityReceiving
+import com.ofg.infrastructure.web.resttemplate.fluent.common.response.receive.*
 import groovy.transform.TypeChecked
 import org.springframework.http.HttpEntity
 import org.springframework.http.HttpMethod
@@ -29,19 +26,21 @@ import static org.springframework.http.HttpMethod.OPTIONS
  */
 @TypeChecked
 class OptionsMethodBuilder implements
-        OptionsMethod, UrlParameterizableOptionsMethod,
-        ResponseReceivingOptionsMethod, AllowHeaderReceiving {
+        OptionsMethod, UrlParameterizableOptionsMethod, ResponseReceivingOptionsMethod, AllowHeaderReceiving,
+        QueryParametersHaving<ResponseReceivingOptionsMethod> {
 
     private final Map params = [:]
     private final RestOperations restOperations
     private final RetryExecutor retryExecutor
     private final AllowContainingWithHeaders withHeaders
+    private final BodylessWithQueryParameters<ResponseReceivingOptionsMethod> withQueryParameters
     private final OptionsAllowHeaderExecutor allowHeaderExecutor
 
     OptionsMethodBuilder(Callable<String> host, RestOperations restOperations, PredefinedHttpHeaders predefinedHeaders, RetryExecutor retryExecutor) {
         this.restOperations = restOperations
         params.host = host
         withHeaders = new AllowContainingWithHeaders(this, params, predefinedHeaders)
+        withQueryParameters = new BodylessWithQueryParameters<ResponseReceivingOptionsMethod>(this, params)
         allowHeaderExecutor = new OptionsAllowHeaderExecutor(restOperations, retryExecutor, params)
         this.retryExecutor = retryExecutor
     }
@@ -55,7 +54,7 @@ class OptionsMethodBuilder implements
         params.url = url
         return this
     }
-    
+
     @Override
     ResponseReceivingOptionsMethod onUrl(String url) {
         params.url = new URI(url)
@@ -167,5 +166,10 @@ class OptionsMethodBuilder implements
     @Override
     HeadersSetting<ResponseReceivingOptionsMethod> withHeaders() {
         return withHeaders.withHeaders()
+    }
+
+    @Override
+    QueryParametersSetting<ResponseReceivingOptionsMethod> withQueryParameters() {
+        return withQueryParameters.withQueryParameters()
     }
 }

--- a/micro-infra-spring-base/src/main/groovy/com/ofg/infrastructure/web/resttemplate/fluent/post/PostMethodBuilder.groovy
+++ b/micro-infra-spring-base/src/main/groovy/com/ofg/infrastructure/web/resttemplate/fluent/post/PostMethodBuilder.groovy
@@ -7,9 +7,7 @@ import com.nurkiewicz.asyncretry.RetryExecutor
 import com.nurkiewicz.asyncretry.SyncRetryExecutor
 import com.ofg.infrastructure.web.resttemplate.fluent.UrlUtils
 import com.ofg.infrastructure.web.resttemplate.fluent.common.response.executor.ResponseTypeRelatedRequestsExecutor
-import com.ofg.infrastructure.web.resttemplate.fluent.common.response.receive.ObjectReceiving
-import com.ofg.infrastructure.web.resttemplate.fluent.common.response.receive.PredefinedHttpHeaders
-import com.ofg.infrastructure.web.resttemplate.fluent.common.response.receive.ResponseEntityReceiving
+import com.ofg.infrastructure.web.resttemplate.fluent.common.response.receive.*
 import groovy.transform.TypeChecked
 import org.springframework.http.HttpMethod
 import org.springframework.http.ResponseEntity
@@ -29,9 +27,12 @@ class PostMethodBuilder extends DataUpdateMethodBuilder<RequestHavingPostMethod,
         PostMethod, RequestHavingPostMethod, ResponseReceivingPostMethod,
         UrlParameterizablePostMethod {
 
+    private final BodyContainingWithQueryParameters<ResponseReceivingPostMethod> withQueryParameters
+
     PostMethodBuilder(Callable<String> host, RestOperations restOperations, PredefinedHttpHeaders predefinedHeaders, RetryExecutor retryExecutor) {
         super(predefinedHeaders, restOperations, retryExecutor)
         params.host = host
+        withQueryParameters = new BodyContainingWithQueryParameters<ResponseReceivingPostMethod>(this, params)
     }
 
     PostMethodBuilder(RestOperations restOperations) {
@@ -106,5 +107,10 @@ class PostMethodBuilder extends DataUpdateMethodBuilder<RequestHavingPostMethod,
     ListenableFuture<Void> ignoringResponseAsync() {
         ListenableFuture<ResponseEntity<Object>> future = aResponseEntity().ofTypeAsync(Object)
         return Futures.transform(future, {null} as Function<ResponseEntity<Object>, Void>)
+    }
+
+    @Override
+    QueryParametersSetting<ResponseReceivingPostMethod> withQueryParameters() {
+        return withQueryParameters.withQueryParameters()
     }
 }

--- a/micro-infra-spring-base/src/main/groovy/com/ofg/infrastructure/web/resttemplate/fluent/put/PutMethodBuilder.groovy
+++ b/micro-infra-spring-base/src/main/groovy/com/ofg/infrastructure/web/resttemplate/fluent/put/PutMethodBuilder.groovy
@@ -28,10 +28,12 @@ class PutMethodBuilder extends DataUpdateMethodBuilder<RequestHavingPutMethod, U
         PutMethod, RequestHavingPutMethod, ResponseReceivingPutMethod,
         UrlParameterizablePutMethod {
 
+    private final WithQueryParameters<ResponseReceivingPutMethod> withQueryParameters
+
     PutMethodBuilder(Callable<String> host, RestOperations restOperations, PredefinedHttpHeaders predefinedHeaders, RetryExecutor retryExecutor) {
         super(predefinedHeaders, restOperations, retryExecutor)
         params.host = host
-
+        withQueryParameters = new BodyContainingWithQueryParameters<ResponseReceivingPutMethod>(this, params)
     }
 
     @Override
@@ -105,5 +107,10 @@ class PutMethodBuilder extends DataUpdateMethodBuilder<RequestHavingPutMethod, U
     ListenableFuture<Void> ignoringResponseAsync() {
         ListenableFuture<ResponseEntity<Object>> future = aResponseEntity().ofTypeAsync(Object)
         return Futures.transform(future, { null } as Function<ResponseEntity<Object>, Void>)
+    }
+
+    @Override
+    QueryParametersSetting<ResponseReceivingPutMethod> withQueryParameters() {
+        return withQueryParameters.withQueryParameters()
     }
 }

--- a/micro-infra-spring-base/src/main/java/com/ofg/infrastructure/web/resttemplate/fluent/UrlUtils.java
+++ b/micro-infra-spring-base/src/main/java/com/ofg/infrastructure/web/resttemplate/fluent/UrlUtils.java
@@ -23,9 +23,10 @@ public class UrlUtils {
             validateParameters(paramName);
             urlParametersBuilder.append(concatenator);
             urlParametersBuilder.append(paramName);
-            urlParametersBuilder.append(PARAMETERS_ASSIGNMENT);
             Object parameterValue = params.get(paramName);
+
             if (parameterValue != null && !parameterValue.toString().isEmpty()) {
+                urlParametersBuilder.append(PARAMETERS_ASSIGNMENT);
                 urlParametersBuilder.append(parameterValue.toString());
             }
             concatenator = SECOND_AND_LATER_CONCATENATOR;

--- a/micro-infra-spring-base/src/main/java/com/ofg/infrastructure/web/resttemplate/fluent/UrlUtils.java
+++ b/micro-infra-spring-base/src/main/java/com/ofg/infrastructure/web/resttemplate/fluent/UrlUtils.java
@@ -12,26 +12,30 @@ public class UrlUtils {
     private static final String PARAMETERS_ASSIGNMENT = "=";
     private static final String SECOND_AND_LATER_CONCATENATOR = "&";
 
-    public static URI addQueryParametersToUri(URI uri, Map<String, Object> params) throws URISyntaxException {
+    public static URI addQueryParametersToUri(URI uri, Map<String, Object> parameters) throws URISyntaxException {
         StringBuilder urlParametersBuilder = new StringBuilder();
         if (uri == null) {
             throw new IllegalArgumentException("Define URL before URL parameters");
         }
         urlParametersBuilder.append(uri.toString());
         String concatenator = FIRST_PARAMETER_CONCATENATOR;
-        for (String paramName : params.keySet()) {
+        for (String paramName : parameters.keySet()) {
             validateParameters(paramName);
             urlParametersBuilder.append(concatenator);
             urlParametersBuilder.append(paramName);
-            Object parameterValue = params.get(paramName);
+            Object parameterValue = parameters.get(paramName);
 
-            if (parameterValue != null && !parameterValue.toString().isEmpty()) {
+            if (doesContainValue(parameterValue)) {
                 urlParametersBuilder.append(PARAMETERS_ASSIGNMENT);
                 urlParametersBuilder.append(parameterValue.toString());
             }
             concatenator = SECOND_AND_LATER_CONCATENATOR;
         }
         return new URI(urlParametersBuilder.toString());
+    }
+
+    private static boolean doesContainValue(Object value) {
+        return value!=null && !value.toString().equals("");
     }
 
     private static void validateParameters(String paramName) {

--- a/micro-infra-spring-base/src/main/java/com/ofg/infrastructure/web/resttemplate/fluent/common/response/receive/ParametersSetting.java
+++ b/micro-infra-spring-base/src/main/java/com/ofg/infrastructure/web/resttemplate/fluent/common/response/receive/ParametersSetting.java
@@ -1,0 +1,11 @@
+package com.ofg.infrastructure.web.resttemplate.fluent.common.response.receive;
+
+import com.ofg.infrastructure.web.resttemplate.fluent.common.response.executor.Executable;
+
+/**
+ * Interface that provides methods to set parameters on HTTP GET requests
+ *
+ * @param < T > - interface to return via {@link Executable} when you have finished setting headers
+ */
+public interface ParametersSetting<T> extends Executable<T> {
+}

--- a/micro-infra-spring-base/src/main/java/com/ofg/infrastructure/web/resttemplate/fluent/common/response/receive/QueryParametersSetting.java
+++ b/micro-infra-spring-base/src/main/java/com/ofg/infrastructure/web/resttemplate/fluent/common/response/receive/QueryParametersSetting.java
@@ -1,0 +1,12 @@
+package com.ofg.infrastructure.web.resttemplate.fluent.common.response.receive;
+
+import com.ofg.infrastructure.web.resttemplate.fluent.common.response.executor.Executable;
+
+/**
+ * Interface that provides methods to set query parameters on HTTP requests
+ *
+ * @param < T > - interface to return via {@link Executable} when you have finished setting query parameters
+ */
+public interface QueryParametersSetting<T> extends Executable<T> {
+    QueryParametersSetting<T> parameter(String name, Object value);
+}

--- a/micro-infra-spring-base/src/main/java/com/ofg/infrastructure/web/resttemplate/fluent/common/response/receive/WithQueryParameters.java
+++ b/micro-infra-spring-base/src/main/java/com/ofg/infrastructure/web/resttemplate/fluent/common/response/receive/WithQueryParameters.java
@@ -6,8 +6,8 @@ import groovy.transform.TypeChecked;
 
 import java.net.URI;
 import java.net.URISyntaxException;
-import java.util.HashMap;
 import java.util.Map;
+import java.util.TreeMap;
 
 /**
  * Default implementation of query parameters setting for requests
@@ -17,7 +17,7 @@ import java.util.Map;
 @TypeChecked
 public class WithQueryParameters<T> implements QueryParametersSetting<T>, QueryParametersHaving<T> {
     private final T parent;
-    private final Map<String, Object> queryParams = new HashMap<>();
+    private final Map<String, Object> queryParams = new TreeMap<>();
     private Map params;
 
     public WithQueryParameters(T parent, Map<String, Object> params) {

--- a/micro-infra-spring-base/src/main/java/com/ofg/infrastructure/web/resttemplate/fluent/common/response/receive/WithQueryParameters.java
+++ b/micro-infra-spring-base/src/main/java/com/ofg/infrastructure/web/resttemplate/fluent/common/response/receive/WithQueryParameters.java
@@ -1,0 +1,48 @@
+package com.ofg.infrastructure.web.resttemplate.fluent.common.response.receive;
+
+import com.google.common.base.Throwables;
+import com.ofg.infrastructure.web.resttemplate.fluent.UrlUtils;
+import groovy.transform.TypeChecked;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Default implementation of query parameters setting for requests
+ *
+ * @param < T > - original class to be returned once query parameters setting has finished
+ */
+@TypeChecked
+public class WithQueryParameters<T> implements QueryParametersSetting<T>, QueryParametersHaving<T> {
+    private final T parent;
+    private final Map<String, Object> queryParams = new HashMap<>();
+    private Map params;
+
+    public WithQueryParameters(T parent, Map<String, Object> params) {
+        this.parent = parent;
+        this.params = params;
+    }
+
+    @Override
+    public T andExecuteFor() {
+        return parent;
+    }
+
+    @Override
+    public QueryParametersSetting<T> withQueryParameters() {
+        return this;
+    }
+
+    @Override
+    public QueryParametersSetting<T> parameter(String key, Object value) {
+        queryParams.put(key, value);
+        try {
+            params.put("urlWithQueryParameters", UrlUtils.addQueryParametersToUri((URI) params.get("url"), queryParams));
+        } catch (URISyntaxException e) {
+            Throwables.propagate(e);
+        }
+        return this;
+    }
+}

--- a/micro-infra-spring-base/src/test/groovy/com/ofg/infrastructure/web/resttemplate/fluent/UrlUtilsSpec.groovy
+++ b/micro-infra-spring-base/src/test/groovy/com/ofg/infrastructure/web/resttemplate/fluent/UrlUtilsSpec.groovy
@@ -21,7 +21,7 @@ class UrlUtilsSpec extends Specification {
         when:
             URI result = UrlUtils.addQueryParametersToUri(new URI(""), parameters)
         then:
-            result.toString() == "?firstParam=&secondParam="
+            result.toString() == "?firstParam&secondParam"
     }
 
     @Unroll("should not add '#paramName' as parameter name")

--- a/micro-infra-spring-base/src/test/groovy/com/ofg/infrastructure/web/resttemplate/fluent/delete/DeleteHttpMethodBuilderSpec.groovy
+++ b/micro-infra-spring-base/src/test/groovy/com/ofg/infrastructure/web/resttemplate/fluent/delete/DeleteHttpMethodBuilderSpec.groovy
@@ -3,12 +3,11 @@ package com.ofg.infrastructure.web.resttemplate.fluent.delete
 import com.ofg.infrastructure.web.resttemplate.fluent.HttpMethodBuilder
 import com.ofg.infrastructure.web.resttemplate.fluent.common.HttpMethodSpec
 
-import static com.ofg.infrastructure.web.resttemplate.fluent.common.response.receive.PredefinedHttpHeaders.*
+import static com.ofg.infrastructure.web.resttemplate.fluent.common.response.receive.PredefinedHttpHeaders.NO_PREDEFINED_HEADERS
 import org.springframework.http.HttpEntity
 import org.springframework.http.ResponseEntity
 
 import static org.springframework.http.HttpMethod.DELETE
-import static org.springframework.http.HttpMethod.GET
 import static org.springframework.http.HttpStatus.OK
 
 class DeleteHttpMethodBuilderSpec extends HttpMethodSpec {
@@ -139,10 +138,29 @@ class DeleteHttpMethodBuilderSpec extends HttpMethodSpec {
                     .withQueryParameters(['parameterOne': 'valueOne', 'parameterTwo': null])
                     .ignoringResponse()
         then:
-            1 * restOperations.exchange(new URI(FULL_SERVICE_URL + "?parameterOne=valueOne&parameterTwo="), DELETE, new HttpEntity<Object>(null), Object)
+            1 * restOperations.exchange(new URI(FULL_SERVICE_URL + "?parameterOne=valueOne&parameterTwo"),
+                    DELETE,
+                    _ as HttpEntity,
+                    Object)
     }
 
-    private boolean hasNoContentTypeHeaderSet(HttpEntity it) {
-        it.getHeaders().getContentType() == null
+    def "should add parameters to query string when sending request to a service via DSL"() {
+        given:
+            httpMethodBuilder = new HttpMethodBuilder(SERVICE_URL, restOperations, NO_PREDEFINED_HEADERS)
+        when:
+            httpMethodBuilder
+                    .delete()
+                    .onUrl(PATH)
+                    .withQueryParameters()
+                        .parameter("size",123)
+                        .parameter("sort",null)
+                        .parameter("filter","")
+                    .andExecuteFor()
+                    .ignoringResponse()
+        then:
+            1 * restOperations.exchange(new URI(FULL_SERVICE_URL + "?filter&size=123&sort"),
+                    DELETE,
+                    _ as HttpEntity,
+                    Object)
     }
 }

--- a/micro-infra-spring-base/src/test/groovy/com/ofg/infrastructure/web/resttemplate/fluent/get/GetHttpMethodBuilderSpec.groovy
+++ b/micro-infra-spring-base/src/test/groovy/com/ofg/infrastructure/web/resttemplate/fluent/get/GetHttpMethodBuilderSpec.groovy
@@ -162,7 +162,7 @@ class GetHttpMethodBuilderSpec extends HttpMethodSpec {
                     .anObject()
                     .ofType(BigDecimal)
         then:
-            1 * restOperations.exchange(new URI(FULL_SERVICE_URL + "?parameterOne=valueOne&parameterTwo="), GET, _ as HttpEntity, BigDecimal)
+            1 * restOperations.exchange(new URI(FULL_SERVICE_URL + "?parameterOne=valueOne&parameterTwo"), GET, _ as HttpEntity, BigDecimal)
     }
 
 }

--- a/micro-infra-spring-base/src/test/groovy/com/ofg/infrastructure/web/resttemplate/fluent/get/GetHttpMethodBuilderSpec.groovy
+++ b/micro-infra-spring-base/src/test/groovy/com/ofg/infrastructure/web/resttemplate/fluent/get/GetHttpMethodBuilderSpec.groovy
@@ -175,12 +175,15 @@ class GetHttpMethodBuilderSpec extends HttpMethodSpec {
                 .withQueryParameters()
                     .parameter("size",123)
                     .parameter("sort",null)
-                    .parameter("filter",Optional.empty())
+                    .parameter("filter","")
                 .andExecuteFor()
                 .anObject()
                 .ofType(BigDecimal)
         then:
-            1 * restOperations.exchange(new URI(FULL_SERVICE_URL + "?size=123&sort&filter"), GET, _ as HttpEntity, BigDecimal)
+            1 * restOperations.exchange(new URI(FULL_SERVICE_URL + "?filter&size=123&sort"),
+                    GET,
+                    _ as HttpEntity,
+                    BigDecimal)
     }
 
 }

--- a/micro-infra-spring-base/src/test/groovy/com/ofg/infrastructure/web/resttemplate/fluent/get/GetHttpMethodBuilderSpec.groovy
+++ b/micro-infra-spring-base/src/test/groovy/com/ofg/infrastructure/web/resttemplate/fluent/get/GetHttpMethodBuilderSpec.groovy
@@ -165,4 +165,22 @@ class GetHttpMethodBuilderSpec extends HttpMethodSpec {
             1 * restOperations.exchange(new URI(FULL_SERVICE_URL + "?parameterOne=valueOne&parameterTwo"), GET, _ as HttpEntity, BigDecimal)
     }
 
+    def "should add parameters to query string when sending request to a service via DSL"() {
+        given:
+            httpMethodBuilder = new HttpMethodBuilder(SERVICE_URL, restOperations, NO_PREDEFINED_HEADERS)
+        when:
+            httpMethodBuilder
+                .get()
+                .onUrl(PATH)
+                .withQueryParameters()
+                    .parameter("size",123)
+                    .parameter("sort",null)
+                    .parameter("filter",Optional.empty())
+                .andExecuteFor()
+                .anObject()
+                .ofType(BigDecimal)
+        then:
+            1 * restOperations.exchange(new URI(FULL_SERVICE_URL + "?size=123&sort&filter"), GET, _ as HttpEntity, BigDecimal)
+    }
+
 }

--- a/micro-infra-spring-base/src/test/groovy/com/ofg/infrastructure/web/resttemplate/fluent/head/HeadHttpMethodBuilderSpec.groovy
+++ b/micro-infra-spring-base/src/test/groovy/com/ofg/infrastructure/web/resttemplate/fluent/head/HeadHttpMethodBuilderSpec.groovy
@@ -1,13 +1,11 @@
 package com.ofg.infrastructure.web.resttemplate.fluent.head
-
 import com.ofg.infrastructure.web.resttemplate.fluent.HttpMethodBuilder
 import com.ofg.infrastructure.web.resttemplate.fluent.common.HttpMethodSpec
 import org.springframework.http.HttpEntity
 import org.springframework.http.HttpHeaders
 import org.springframework.http.ResponseEntity
 
-import static com.ofg.infrastructure.web.resttemplate.fluent.common.response.receive.PredefinedHttpHeaders.*
-import static org.springframework.http.HttpMethod.GET
+import static com.ofg.infrastructure.web.resttemplate.fluent.common.response.receive.PredefinedHttpHeaders.NO_PREDEFINED_HEADERS
 import static org.springframework.http.HttpMethod.HEAD
 import static org.springframework.http.HttpStatus.OK
 
@@ -161,7 +159,26 @@ class HeadHttpMethodBuilderSpec extends HttpMethodSpec {
                     .andExecuteFor()
                     .ignoringResponse()
         then:
-            1 * restOperations.exchange(new URI(FULL_SERVICE_URL + "?parameterOne=valueOne&parameterTwo="), HEAD, new HttpEntity(null), Object)
+            1 * restOperations.exchange(new URI(FULL_SERVICE_URL + "?parameterOne=valueOne&parameterTwo"), HEAD, new HttpEntity(null), Object)
     }
 
+    def "should add parameters to query string when sending request to a service via DSL"() {
+        given:
+            httpMethodBuilder = new HttpMethodBuilder(SERVICE_URL, restOperations, NO_PREDEFINED_HEADERS)
+        when:
+            httpMethodBuilder
+                    .head()
+                    .onUrl(PATH)
+                    .withQueryParameters()
+                        .parameter("size",123)
+                        .parameter("sort",null)
+                        .parameter("filter","")
+                    .andExecuteFor()
+                    .ignoringResponse()
+        then:
+            1 * restOperations.exchange(new URI(FULL_SERVICE_URL + "?filter&size=123&sort"),
+                    HEAD,
+                    _ as HttpEntity,
+                    Object)
+    }
 }

--- a/micro-infra-spring-base/src/test/groovy/com/ofg/infrastructure/web/resttemplate/fluent/options/OptionsHttpMethodBuilderSpec.groovy
+++ b/micro-infra-spring-base/src/test/groovy/com/ofg/infrastructure/web/resttemplate/fluent/options/OptionsHttpMethodBuilderSpec.groovy
@@ -2,14 +2,13 @@ package com.ofg.infrastructure.web.resttemplate.fluent.options
 
 import com.ofg.infrastructure.web.resttemplate.fluent.HttpMethodBuilder
 import com.ofg.infrastructure.web.resttemplate.fluent.common.HttpMethodSpec
-import static com.ofg.infrastructure.web.resttemplate.fluent.common.response.receive.PredefinedHttpHeaders.*
 import org.springframework.http.HttpEntity
 import org.springframework.http.HttpHeaders
 import org.springframework.http.HttpMethod
 import org.springframework.http.ResponseEntity
 
+import static com.ofg.infrastructure.web.resttemplate.fluent.common.response.receive.PredefinedHttpHeaders.NO_PREDEFINED_HEADERS
 import static org.springframework.http.HttpMethod.DELETE
-import static org.springframework.http.HttpMethod.HEAD
 import static org.springframework.http.HttpMethod.OPTIONS
 import static org.springframework.http.HttpStatus.OK
 
@@ -172,7 +171,30 @@ class OptionsHttpMethodBuilderSpec extends HttpMethodSpec {
                     .andExecuteFor()
                     .ignoringResponse()
         then:
-            1 * restOperations.exchange(new URI(FULL_SERVICE_URL + "?parameterOne=valueOne&parameterTwo="), OPTIONS, new HttpEntity(null), Object)
+            1 * restOperations.exchange(new URI(FULL_SERVICE_URL + "?parameterOne=valueOne&parameterTwo"),
+                    OPTIONS,
+                    new HttpEntity(null),
+                    Object)
+    }
+
+    def "should add parameters to query string when sending request to a service via DSL"() {
+        given:
+            httpMethodBuilder = new HttpMethodBuilder(SERVICE_URL, restOperations, NO_PREDEFINED_HEADERS)
+        when:
+            httpMethodBuilder
+                    .options()
+                    .onUrl(PATH)
+                    .withQueryParameters()
+                        .parameter("size",123)
+                        .parameter("sort",null)
+                        .parameter("filter","")
+                    .andExecuteFor()
+                    .ignoringResponse()
+        then:
+            1 * restOperations.exchange(new URI(FULL_SERVICE_URL + "?filter&size=123&sort"),
+                    OPTIONS,
+                    _ as HttpEntity,
+                    Object)
     }
 
 }

--- a/micro-infra-spring-base/src/test/groovy/com/ofg/infrastructure/web/resttemplate/fluent/post/PostHttpMethodBuilderSpec.groovy
+++ b/micro-infra-spring-base/src/test/groovy/com/ofg/infrastructure/web/resttemplate/fluent/post/PostHttpMethodBuilderSpec.groovy
@@ -2,12 +2,11 @@ package com.ofg.infrastructure.web.resttemplate.fluent.post
 
 import com.ofg.infrastructure.web.resttemplate.fluent.HttpMethodBuilder
 import com.ofg.infrastructure.web.resttemplate.fluent.common.HttpMethodSpec
-import static com.ofg.infrastructure.web.resttemplate.fluent.common.response.receive.PredefinedHttpHeaders.*
 import org.springframework.http.HttpEntity
 import org.springframework.http.HttpHeaders
 import org.springframework.http.ResponseEntity
 
-import static org.springframework.http.HttpMethod.HEAD
+import static com.ofg.infrastructure.web.resttemplate.fluent.common.response.receive.PredefinedHttpHeaders.NO_PREDEFINED_HEADERS
 import static org.springframework.http.HttpMethod.POST
 import static org.springframework.http.HttpStatus.OK
 
@@ -296,7 +295,30 @@ class PostHttpMethodBuilderSpec extends HttpMethodSpec {
                     .andExecuteFor()
                     .ignoringResponse()
         then:
-            1 * restOperations.exchange(new URI(FULL_SERVICE_URL + "?parameterOne=valueOne&parameterTwo="), POST, new HttpEntity(null), Object)
+            1 * restOperations.exchange(new URI(FULL_SERVICE_URL + "?parameterOne=valueOne&parameterTwo"),
+                    POST,
+                    new HttpEntity(null),
+                    Object)
+    }
+
+    def "should add parameters to query string when sending request to a service via DSL"() {
+        given:
+            httpMethodBuilder = new HttpMethodBuilder(SERVICE_URL, restOperations, NO_PREDEFINED_HEADERS)
+        when:
+            httpMethodBuilder
+                    .post()
+                    .onUrl(PATH)
+                    .withQueryParameters()
+                        .parameter("size",123)
+                        .parameter("sort",null)
+                        .parameter("filter","")
+                    .andExecuteFor()
+                    .ignoringResponse()
+        then:
+            1 * restOperations.exchange(new URI(FULL_SERVICE_URL + "?filter&size=123&sort"),
+                    POST,
+                    _ as HttpEntity,
+                    Object)
     }
 
     private ResponseEntity responseEntityWith(URI expectedLocation) {

--- a/micro-infra-spring-base/src/test/groovy/com/ofg/infrastructure/web/resttemplate/fluent/put/PutHttpMethodBuilderSpec.groovy
+++ b/micro-infra-spring-base/src/test/groovy/com/ofg/infrastructure/web/resttemplate/fluent/put/PutHttpMethodBuilderSpec.groovy
@@ -2,12 +2,11 @@ package com.ofg.infrastructure.web.resttemplate.fluent.put
 
 import com.ofg.infrastructure.web.resttemplate.fluent.HttpMethodBuilder
 import com.ofg.infrastructure.web.resttemplate.fluent.common.HttpMethodSpec
-import static com.ofg.infrastructure.web.resttemplate.fluent.common.response.receive.PredefinedHttpHeaders.*
 import org.springframework.http.HttpEntity
 import org.springframework.http.HttpHeaders
 import org.springframework.http.ResponseEntity
 
-import static org.springframework.http.HttpMethod.HEAD
+import static com.ofg.infrastructure.web.resttemplate.fluent.common.response.receive.PredefinedHttpHeaders.NO_PREDEFINED_HEADERS
 import static org.springframework.http.HttpMethod.PUT
 import static org.springframework.http.HttpStatus.OK
 
@@ -231,7 +230,30 @@ class PutHttpMethodBuilderSpec extends HttpMethodSpec {
                     .andExecuteFor()
                     .ignoringResponse()
         then:
-            1 * restOperations.exchange(new URI(FULL_SERVICE_URL + "?parameterOne=valueOne&parameterTwo="), PUT, new HttpEntity(null), Object)
+            1 * restOperations.exchange(new URI(FULL_SERVICE_URL + "?parameterOne=valueOne&parameterTwo"),
+                    PUT,
+                    new HttpEntity(null),
+                    Object)
+    }
+
+    def "should add parameters to query string when sending request to a service via DSL"() {
+        given:
+            httpMethodBuilder = new HttpMethodBuilder(SERVICE_URL, restOperations, NO_PREDEFINED_HEADERS)
+        when:
+            httpMethodBuilder
+                    .put()
+                    .onUrl(PATH)
+                    .withQueryParameters()
+                        .parameter("size",123)
+                        .parameter("sort",null)
+                        .parameter("filter","")
+                    .andExecuteFor()
+                    .ignoringResponse()
+        then:
+            1 * restOperations.exchange(new URI(FULL_SERVICE_URL + "?filter&size=123&sort"),
+                    PUT,
+                    _ as HttpEntity,
+                    Object)
     }
 
     private ResponseEntity responseEntityWith(URI expectedLocation) {


### PR DESCRIPTION
Parameters should not contain assignment (equals sign) in case of empty or null values.
"?param is valid"