### PR TITLE
When decrypting, {cipher} prefix is optionally allowed

### DIFF
--- a/micro-infra-spring-config/src/main/ruby/aes.rb
+++ b/micro-infra-spring-config/src/main/ruby/aes.rb
@@ -17,7 +17,7 @@ end
 def decrypt(encrypted, password)
     CIPHER.decrypt
     CIPHER.key = key(password)
-    decrypted_bytes = CIPHER.update([encrypted].pack('H*')) + CIPHER.final
+    decrypted_bytes = CIPHER.update([encrypted.sub(/^\{cipher\}/, '')].pack('H*')) + CIPHER.final
     return decrypted_bytes[16..-1]
 end
 


### PR DESCRIPTION
aes.rb -d can accept encrypted secrets with and without prefix, previously it was crashing with prefix