### PR TITLE
Correlation ID passed to CorrelationIdUpdater.withId() is not cleaned afterwards

### DIFF
--- a/micro-infra-spring-base/src/main/groovy/com/ofg/infrastructure/correlationid/CorrelationIdUpdater.groovy
+++ b/micro-infra-spring-base/src/main/groovy/com/ofg/infrastructure/correlationid/CorrelationIdUpdater.groovy
@@ -24,11 +24,9 @@ import static com.ofg.infrastructure.correlationid.CorrelationIdHolder.CORRELATI
 class CorrelationIdUpdater {
 
     static void updateCorrelationId(String correlationId) {
-        if (StringUtils.hasText(correlationId)) {
-            log.debug("Updating correlationId with value: [$correlationId]")
-            CorrelationIdHolder.set(correlationId)
-            MDC.put(CORRELATION_ID_HEADER, correlationId)
-        }
+        log.debug("Updating correlationId with value: [$correlationId]")
+        CorrelationIdHolder.set(correlationId)
+        MDC.put(CORRELATION_ID_HEADER, correlationId)
     }
 
     /**

--- a/micro-infra-spring-base/src/test/groovy/com/ofg/infrastructure/correlationid/CorrelationIdUpdaterSpec.groovy
+++ b/micro-infra-spring-base/src/test/groovy/com/ofg/infrastructure/correlationid/CorrelationIdUpdaterSpec.groovy
@@ -35,6 +35,13 @@ class CorrelationIdUpdaterSpec extends Specification {
             CorrelationIdHolder.get() == 'A'
     }
 
+    def 'should clean up correlation ID after running closure when thread had no correlation ID'() {
+        when:
+            CorrelationIdUpdater.withId('C') {}
+        then:
+            CorrelationIdHolder.get() == null
+    }
+
     def "correlation ID should not be propagated to other thread by default"() {
         given:
             CorrelationIdUpdater.updateCorrelationId('A')


### PR DESCRIPTION
If thread has no correlation ID attached, after calling withId() this explicit CID remains

This happens because during cleanup we call updateCorrelationId(null), which does nothing rather than cleaning up. CC: @cameleeck, @uchoromanska.