### PR TITLE
[#547] Upgrade cglib to 3.2.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -134,7 +134,7 @@ configure(srcSubprojects) {
             dependency "ch.qos.logback:logback-classic:1.1.3"
             dependency "com.jayway.restassured:rest-assured:2.4.1"
             dependency "com.github.tomakehurst:wiremock:2.0.4-beta"
-            dependency "cglib:cglib-nodep:3.1"
+            dependency "cglib:cglib-nodep:3.2.0"
             dependency "org.objenesis:objenesis:2.1"
 
             dependencySet(group:'org.spockframework', version: '1.0-groovy-2.4') {

--- a/micro-deps/build.gradle
+++ b/micro-deps/build.gradle
@@ -52,8 +52,8 @@ project(':micro-deps-root:micro-deps-spring-test-config') {
     dependencies {
         compile project(':micro-deps-root:micro-deps-spring-config')
         compile 'org.codehaus.groovy:groovy-all'
-        compile 'cglib:cglib-nodep:3.1'
-        compile 'org.objenesis:objenesis:2.1'
+        compile 'cglib:cglib-nodep'
+        compile 'org.objenesis:objenesis'
         compile 'org.aspectj:aspectjweaver'
 
         compile "org.spockframework:spock-core"


### PR DESCRIPTION
Which fixes Spock mocking issue when Java 8 is used (like this: https://groups.google.com/forum/#!topic/spockframework/59WIHGgcSNE).

Fixes #547.