### PR TITLE
[#551] Ability to disabled metrics configuration

### DIFF
--- a/micro-infra-spring-base/src/main/java/com/ofg/infrastructure/metrics/config/MetricsConfiguration.java
+++ b/micro-infra-spring-base/src/main/java/com/ofg/infrastructure/metrics/config/MetricsConfiguration.java
@@ -15,6 +15,7 @@ import org.apache.commons.lang.StringUtils;
 import org.slf4j.Logger;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.cloud.zookeeper.discovery.ZookeeperDiscoveryProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Conditional;
@@ -48,6 +49,7 @@ import static org.springframework.util.StringUtils.isEmpty;
  * @see EnvironmentAwareMetricsBasePath
  */
 @Configuration
+@ConditionalOnProperty(prefix = "metrics", name = "enabled", havingValue = "true", matchIfMissing = true)
 public class MetricsConfiguration {
 
     private static final Logger log = getLogger(lookup().lookupClass());


### PR DESCRIPTION
This PR provides a way to disable metrics configuration with `-Dmetrics.enabled=false` or a Spring property.

The property is not very unique, but I wanted to consistent with other related properties.

Fixes #551.

