### PR TITLE
Simplify parametrized tests with spock-global-unroll

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -138,6 +138,7 @@ configure(srcSubprojects) {
                 entry "spock-core"
                 entry "spock-spring"
             }
+            dependency "info.solidsoft.spock:spock-global-unroll:0.5.0"
             dependencySet(group:'com.jayway.awaitility', version: '1.6.3') {
                 entry "awaitility"
                 entry "awaitility-groovy"
@@ -252,6 +253,12 @@ if (project.hasProperty("coverage")) {
         srcSubprojects*.test
         srcSubprojects*.jacocoTestReport
     }
+}
+
+//Individual HTML test reports could be disabled to speed up build a little bit if testReport was the only one used - http://stackoverflow.com/a/16921750
+task testReport(type: TestReport) {
+    destinationDir = file("$buildDir/reports/allTests")
+    reportOn srcSubprojects*.test
 }
 
 wrapper {

--- a/micro-deps/build.gradle
+++ b/micro-deps/build.gradle
@@ -18,6 +18,7 @@ project(':micro-deps-root:micro-deps') {
 
         testCompile "org.codehaus.groovy:groovy-all"
         testCompile "org.spockframework:spock-core"
+        testCompile 'info.solidsoft.spock:spock-global-unroll'
         testCompile 'com.jayway.awaitility:awaitility-groovy'
     }
 }
@@ -43,6 +44,7 @@ project(':micro-deps-root:micro-deps-jax-rs-jersey') {
         testCompile project(':micro-deps-root:micro-deps-spring-config')
         testCompile "org.codehaus.groovy:groovy-all"
         testCompile "org.spockframework:spock-core"
+        testCompile 'info.solidsoft.spock:spock-global-unroll'
         testCompile 'com.jayway.awaitility:awaitility-groovy'
     }
 }
@@ -65,6 +67,7 @@ project(':micro-deps-root:micro-deps-spring-config') {
         testCompile 'org.codehaus.groovy:groovy-all'
         testCompile "org.spockframework:spock-core"
         testCompile "org.spockframework:spock-spring"
+        testCompile 'info.solidsoft.spock:spock-global-unroll'
         testCompile "org.springframework:spring-test"
         testCompile "org.springframework:spring-webmvc"
         testCompile "com.jayway.restassured:rest-assured"

--- a/micro-deps/micro-deps-spring-config/src/test/groovy/com/ofg/infrastructure/discovery/ZookeeperConnectorConditionsSpec.groovy
+++ b/micro-deps/micro-deps-spring-config/src/test/groovy/com/ofg/infrastructure/discovery/ZookeeperConnectorConditionsSpec.groovy
@@ -17,7 +17,6 @@ class ZookeeperConnectorConditionsSpec extends Specification {
     ConditionContext context = Mock()
     AnnotatedTypeMetadata metadata = Mock()
 
-    @Unroll
     def '[#condition.class.simpleName] should evaluate to [#expectedOutcome] with profile [#activeProfile] and env[#envProperty]'() {
         given:
             MockEnvironment mockEnv = new MockEnvironment()

--- a/micro-deps/micro-deps/src/test/groovy/com/ofg/infrastructure/discovery/ServiceConfigurationResolverSpec.groovy
+++ b/micro-deps/micro-deps/src/test/groovy/com/ofg/infrastructure/discovery/ServiceConfigurationResolverSpec.groovy
@@ -72,7 +72,6 @@ class ServiceConfigurationResolverSpec extends Specification {
             resolver.dependencies.empty
     }
 
-    @Unroll
     def 'should provide #loadBalancerType for given service #path'() {
         given:
             def resolver = new ServiceConfigurationResolver(LOAD_BALANCING_DEPENDENCIES)

--- a/micro-deps/micro-deps/src/test/groovy/com/ofg/infrastructure/discovery/ServicePathSpec.groovy
+++ b/micro-deps/micro-deps/src/test/groovy/com/ofg/infrastructure/discovery/ServicePathSpec.groovy
@@ -5,7 +5,6 @@ import spock.lang.Unroll
 
 class ServicePathSpec extends Specification {
 
-    @Unroll
     def "should retrieve last name [#expectedLastName] for path [#path]"() {
         expect:
             new ServicePath(path).lastName == expectedLastName
@@ -16,7 +15,6 @@ class ServicePathSpec extends Specification {
             null                         || ''
     }
 
-    @Unroll
     def "should retrieve path to last name [#expectedPathToLastName] for path [#path]"() {
         expect:
             new ServicePath(path).pathToLastName == expectedPathToLastName

--- a/micro-deps/micro-deps/src/test/groovy/com/ofg/infrastructure/discovery/util/LoadBalancerTypeSpec.groovy
+++ b/micro-deps/micro-deps/src/test/groovy/com/ofg/infrastructure/discovery/util/LoadBalancerTypeSpec.groovy
@@ -5,7 +5,6 @@ import spock.lang.Unroll
 
 class LoadBalancerTypeSpec extends Specification {
 
-    @Unroll
     def 'should return ROUND_ROBIN if invalid value [#value] has been provided'() {
         expect:
             LoadBalancerType.ROUND_ROBIN == LoadBalancerType.fromName(value)

--- a/micro-deps/micro-deps/src/test/groovy/com/ofg/infrastructure/discovery/util/ProviderStrategyFactorySpec.groovy
+++ b/micro-deps/micro-deps/src/test/groovy/com/ofg/infrastructure/discovery/util/ProviderStrategyFactorySpec.groovy
@@ -10,7 +10,6 @@ import static com.ofg.infrastructure.discovery.util.LoadBalancerType.*
 
 class ProviderStrategyFactorySpec extends Specification {
 
-    @Unroll
     def 'should create #strategyProviderName provider for #strategyName'() {
         given:
             ProviderStrategyFactory factory = new ProviderStrategyFactory()

--- a/micro-infra-camel/build.gradle
+++ b/micro-infra-camel/build.gradle
@@ -11,8 +11,9 @@ dependencies {
     }
 
     testCompile "org.spockframework:spock-core"
-    testCompile "org.codehaus.groovy:groovy-all"
     testRuntime "org.spockframework:spock-spring"
+    testCompile 'info.solidsoft.spock:spock-global-unroll'
+    testCompile "org.codehaus.groovy:groovy-all"
     testCompile "org.apache.camel:camel-test-spring:$camelVersion"
     testCompile "org.springframework:spring-test"
     testCompile 'cglib:cglib-nodep:3.1'

--- a/micro-infra-spring-base/build.gradle
+++ b/micro-infra-spring-base/build.gradle
@@ -28,6 +28,7 @@ dependencies {
 
     testCompile "org.spockframework:spock-core"
     testRuntime "org.spockframework:spock-spring"
+    testCompile 'info.solidsoft.spock:spock-global-unroll'
     testCompile "org.springframework:spring-test"
     testCompile 'org.hamcrest:hamcrest-library:1.3'
     testCompile 'org.hibernate:hibernate-validator:5.1.3.Final'

--- a/micro-infra-spring-base/src/test/groovy/com/ofg/infrastructure/environment/EnvironmentSetupVerifierSpec.groovy
+++ b/micro-infra-spring-base/src/test/groovy/com/ofg/infrastructure/environment/EnvironmentSetupVerifierSpec.groovy
@@ -31,7 +31,6 @@ class EnvironmentSetupVerifierSpec extends Specification {
             thrown(CheckExitCalled)
     }
 
-    @Unroll
     def "should not let run program with unknown profile [#activeProfiles]"() {
         given:
             environment.setActiveProfiles(activeProfiles as String[])

--- a/micro-infra-spring-base/src/test/groovy/com/ofg/infrastructure/healthcheck/PingClientTest.groovy
+++ b/micro-infra-spring-base/src/test/groovy/com/ofg/infrastructure/healthcheck/PingClientTest.groovy
@@ -14,7 +14,6 @@ import spock.lang.Unroll
 import static com.github.tomakehurst.wiremock.client.WireMock.aResponse
 import static com.ofg.infrastructure.base.dsl.WireMockHttpRequestMapper.wireMockGet
 
-@Unroll
 @ContextConfiguration(classes = [BaseConfiguration, MockServerConfiguration, ServiceResolverConfiguration,
         CollaboratorsConfiguration, ServiceRestClientConfiguration], loader = SpringApplicationContextLoader)
 class PingClientTest extends MvcWiremockIntegrationSpec {

--- a/micro-infra-spring-base/src/test/groovy/com/ofg/infrastructure/metrics/config/GraphitePublisherRegistrationSpec.groovy
+++ b/micro-infra-spring-base/src/test/groovy/com/ofg/infrastructure/metrics/config/GraphitePublisherRegistrationSpec.groovy
@@ -27,7 +27,6 @@ class GraphitePublisherRegistrationSpec extends Specification {
         applicationContext.register(BaseConfiguration, GraphiteServiceConfig, MetricsConfiguration)
     }
 
-    @Unroll
     def 'should register Graphite beans when Graphite publishing is enabled using #flagValue'() {
         given:
             registerInContext(propertySourceWithGraphitePublishingEnabled(flagValue))
@@ -39,7 +38,6 @@ class GraphitePublisherRegistrationSpec extends Specification {
             flagValue << ['yes', 'on', 'true']
     }
 
-    @Unroll
     def 'should not register Graphite beans when Graphite publishing is disabled using #flagValue'() {
         given:
             registerInContext(propertySourceWithGraphitePublishingDisabled(flagValue))

--- a/micro-infra-spring-base/src/test/groovy/com/ofg/infrastructure/tracing/TracingPropertiesEnablerSpec.groovy
+++ b/micro-infra-spring-base/src/test/groovy/com/ofg/infrastructure/tracing/TracingPropertiesEnablerSpec.groovy
@@ -9,7 +9,6 @@ import spock.lang.Unroll
 
 class TracingPropertiesEnablerSpec extends Specification {
 
-    @Unroll
     def 'should resolve zipkin property to [#propValue] if profile is [#profile] and app env is [#appEnv]'() {
         given:
             ConfigurableApplicationContext context = new AnnotationConfigApplicationContext(TracingPropertiesEnabler)

--- a/micro-infra-spring-base/src/test/groovy/com/ofg/infrastructure/web/correlationid/CorrelationIdAspectSpec.groovy
+++ b/micro-infra-spring-base/src/test/groovy/com/ofg/infrastructure/web/correlationid/CorrelationIdAspectSpec.groovy
@@ -50,7 +50,6 @@ class CorrelationIdAspectSpec extends MicroserviceMvcWiremockSpec {
             wireMock.verifyThat(getRequestedFor(urlMatching('.*')).withHeader(CORRELATION_ID_HEADER, matching(/^(?!\s*$).+/)))
     }
 
-    @Unroll
     def "should set correlationId on header via aspect in asynchronous call using #url"() {
         given:
             stubInteraction(get(urlMatching('.*')), aResponse().withStatus(200))

--- a/micro-infra-spring-base/src/test/groovy/com/ofg/infrastructure/web/resttemplate/RegexMatchingPathElidingURIMetricNamerSpec.groovy
+++ b/micro-infra-spring-base/src/test/groovy/com/ofg/infrastructure/web/resttemplate/RegexMatchingPathElidingURIMetricNamerSpec.groovy
@@ -5,7 +5,6 @@ import spock.lang.Specification
 import spock.lang.Unroll
 
 
-@Unroll
 class RegexMatchingPathElidingURIMetricNamerSpec extends Specification {
 
     def 'should turn "#uriString" into valid metric name: "#expectedMetricName"'() {

--- a/micro-infra-spring-base/src/test/groovy/com/ofg/infrastructure/web/resttemplate/custom/HttpStatusVerifierSpec.groovy
+++ b/micro-infra-spring-base/src/test/groovy/com/ofg/infrastructure/web/resttemplate/custom/HttpStatusVerifierSpec.groovy
@@ -6,7 +6,6 @@ import spock.lang.Unroll
 
 class HttpStatusVerifierSpec extends Specification {
 
-    @Unroll
     def 'should verify that HTTP status [#status] is error [#error]'() {
         expect:
             error == HttpStatusVerifier.isError(status)

--- a/micro-infra-spring-base/src/test/groovy/com/ofg/infrastructure/web/resttemplate/custom/InputStreamPrinterSpec.groovy
+++ b/micro-infra-spring-base/src/test/groovy/com/ofg/infrastructure/web/resttemplate/custom/InputStreamPrinterSpec.groovy
@@ -3,7 +3,6 @@ package com.ofg.infrastructure.web.resttemplate.custom
 import spock.lang.Specification
 import spock.lang.Unroll
 
-@Unroll
 class InputStreamPrinterSpec extends Specification {
 
     def 'should abbreviate "#source" to "#target" with max chars #maxChars'() {

--- a/micro-infra-spring-base/src/test/groovy/com/ofg/infrastructure/web/resttemplate/fluent/HTTPAuthorizationUtilsSpec.groovy
+++ b/micro-infra-spring-base/src/test/groovy/com/ofg/infrastructure/web/resttemplate/fluent/HTTPAuthorizationUtilsSpec.groovy
@@ -5,7 +5,6 @@ import spock.lang.Unroll
 
 import static com.ofg.infrastructure.web.resttemplate.fluent.HTTPAuthorizationUtils.encodeCredentials
 
-@Unroll
 class HTTPAuthorizationUtilsSpec extends Specification {
 
     def "encode basic authentication #username and #password credentials into #authorizationValue"() {

--- a/micro-infra-spring-base/src/test/groovy/com/ofg/infrastructure/web/resttemplate/fluent/UrlUtilsSpec.groovy
+++ b/micro-infra-spring-base/src/test/groovy/com/ofg/infrastructure/web/resttemplate/fluent/UrlUtilsSpec.groovy
@@ -37,7 +37,6 @@ class UrlUtilsSpec extends Specification {
             paramName << ["", null]
     }
 
-    @Unroll
     def "should deal with '#paramName' as parameters names in query string"() {
         given:
             Map parameters = [firstParameter: "valueOne", (paramName): "valueTwo", secondParameter: null]

--- a/micro-infra-spring-base/src/test/groovy/com/ofg/infrastructure/web/resttemplate/fluent/common/response/executor/UrlParsingUtilsSpec.groovy
+++ b/micro-infra-spring-base/src/test/groovy/com/ofg/infrastructure/web/resttemplate/fluent/common/response/executor/UrlParsingUtilsSpec.groovy
@@ -3,7 +3,6 @@ package com.ofg.infrastructure.web.resttemplate.fluent.common.response.executor
 import spock.lang.Specification
 import spock.lang.Unroll
 
-@Unroll
 class UrlParsingUtilsSpec extends Specification {
 
     def 'should fail to instantiate a utility class'() {

--- a/micro-infra-spring-base/src/test/groovy/com/ofg/infrastructure/web/resttemplate/fluent/headers/HeadersSettingSpec.groovy
+++ b/micro-infra-spring-base/src/test/groovy/com/ofg/infrastructure/web/resttemplate/fluent/headers/HeadersSettingSpec.groovy
@@ -304,7 +304,6 @@ class HeadersSettingSpec extends HttpMethodSpec {
                     _ as Long)
     }
 
-    @Unroll
     def "should have 'Authorization' header with value: '#authorizationValue'"() {
         given:
         httpMethodBuilder = new HttpMethodBuilder(restOperations, tracingInfo)

--- a/micro-infra-spring-base/src/test/groovy/com/ofg/infrastructure/web/view/DisablingJsonGeneratorFeaturesSpec.groovy
+++ b/micro-infra-spring-base/src/test/groovy/com/ofg/infrastructure/web/view/DisablingJsonGeneratorFeaturesSpec.groovy
@@ -15,7 +15,6 @@ class DisablingJsonGeneratorFeaturesSpec extends JsonJacksonFeaturesSpec {
         System.properties.remove("json.jackson.generator.off")
     }
 
-    @Unroll
     def "should enable JsonGenerator's feature #generatorFeature"() {
         given:
             def converter = getFirstConfiguredJacksonMessageConverter()

--- a/micro-infra-spring-base/src/test/groovy/com/ofg/infrastructure/web/view/DisablingJsonParserFeaturesSpec.groovy
+++ b/micro-infra-spring-base/src/test/groovy/com/ofg/infrastructure/web/view/DisablingJsonParserFeaturesSpec.groovy
@@ -15,7 +15,6 @@ class DisablingJsonParserFeaturesSpec extends JsonJacksonFeaturesSpec {
         System.properties.remove("json.jackson.parser.off")
     }
 
-    @Unroll
     def "should enable JsonParser's feature #parserFeature"() {
         given:
             def converter = getFirstConfiguredJacksonMessageConverter()

--- a/micro-infra-spring-base/src/test/groovy/com/ofg/infrastructure/web/view/EnablingJsonGeneratorFeaturesSpec.groovy
+++ b/micro-infra-spring-base/src/test/groovy/com/ofg/infrastructure/web/view/EnablingJsonGeneratorFeaturesSpec.groovy
@@ -15,7 +15,6 @@ class EnablingJsonGeneratorFeaturesSpec extends JsonJacksonFeaturesSpec {
         System.properties.remove("json.jackson.generator.on")
     }
 
-    @Unroll
     def "should enable JsonGenerator's feature #generatorFeature"() {
         given:
             def converter = getFirstConfiguredJacksonMessageConverter()

--- a/micro-infra-spring-base/src/test/groovy/com/ofg/infrastructure/web/view/EnablingJsonParserFeaturesSpec.groovy
+++ b/micro-infra-spring-base/src/test/groovy/com/ofg/infrastructure/web/view/EnablingJsonParserFeaturesSpec.groovy
@@ -16,7 +16,6 @@ class EnablingJsonParserFeaturesSpec extends JsonJacksonFeaturesSpec {
         System.properties.remove("json.jackson.parser.on")
     }
 
-    @Unroll
     def "should enable JsonParser's feature #parserFeature"() {
         given:
             def converter = getFirstConfiguredJacksonMessageConverter()

--- a/micro-infra-spring-config/build.gradle
+++ b/micro-infra-spring-config/build.gradle
@@ -23,6 +23,7 @@ dependencies {
     compile 'org.springframework.cloud:spring-cloud-starter-zookeeper-discovery'
 
     testCompile "org.spockframework:spock-core"
+    testCompile 'info.solidsoft.spock:spock-global-unroll'
     testRuntime "org.springframework:spring-test"
     testRuntime "org.spockframework:spock-spring"
     testRuntime "ch.qos.logback:logback-classic"

--- a/micro-infra-spring-config/src/test/groovy/com/ofg/infrastructure/property/AppCoordinatesSpec.groovy
+++ b/micro-infra-spring-config/src/test/groovy/com/ofg/infrastructure/property/AppCoordinatesSpec.groovy
@@ -4,7 +4,6 @@ import spock.lang.Specification
 import spock.lang.Unroll
 
 
-@Unroll
 class AppCoordinatesSpec extends Specification {
 
     def 'should properly resolve config files for name #name'() {

--- a/micro-infra-spring-config/src/test/groovy/com/ofg/infrastructure/property/FileSystemPollerSpec.groovy
+++ b/micro-infra-spring-config/src/test/groovy/com/ofg/infrastructure/property/FileSystemPollerSpec.groovy
@@ -38,7 +38,6 @@ class FileSystemPollerSpec extends AbstractIntegrationSpec {
         poller = context.getBean(FileSystemPoller)
     }
 
-    @Unroll
     def 'should reload configuration once when file #configFile from config location with allowed name is touched'() {
         when:
             oneConfigurationFileWasChanged(configFile)

--- a/stub-runner/stub-runner-spring/build.gradle
+++ b/stub-runner/stub-runner-spring/build.gradle
@@ -10,6 +10,7 @@ dependencies {
     compile 'org.apache.ivy:ivy:2.4.0'
 
     testCompile 'org.spockframework:spock-core'
+    testCompile 'info.solidsoft.spock:spock-global-unroll'
     testCompile 'cglib:cglib-nodep'
     testCompile 'org.objenesis:objenesis'
 }

--- a/stub-runner/stub-runner/build.gradle
+++ b/stub-runner/stub-runner/build.gradle
@@ -20,6 +20,7 @@ dependencies {
     compile 'com.nurkiewicz.asyncretry:asyncretry-jdk7:0.0.6'
 
     testCompile 'org.spockframework:spock-core'
+    testCompile 'info.solidsoft.spock:spock-global-unroll'
     testCompile 'cglib:cglib-nodep'
     testCompile 'org.objenesis:objenesis'
 }


### PR DESCRIPTION
No more `@Unroll` just to enable parameterized tests unrolling :).

As a result number of tests increased from 483 to 497. Probably there was `@Unroll` annotation missing in some places.

By the way the aggregated testReport task was added.