### PR TITLE
fix missing vcsUrl in bintray upload

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -46,6 +46,7 @@ configure(srcSubprojects) {
     bintray {
         pkg {
             repo = project.name.startsWith("micro-deps") ? 'micro-deps' : 'micro'
+            vcsUrl = 'https://github.com/4finance/micro-infra-spring.git'
         }
     }
 }


### PR DESCRIPTION
vcsUrl is one of the mandatory parameters according to docs

[gradle-bintray-plugin](https://github.com/bintray/gradle-bintray-plugin/blob/master/README.md)