### PR TITLE
Adding rxjava as a dependency

### DIFF
--- a/micro-deps/build.gradle
+++ b/micro-deps/build.gradle
@@ -63,6 +63,7 @@ project(':micro-deps-root:micro-deps-spring-config') {
         compile "org.springframework:spring-context"
         compile 'org.springframework.cloud:spring-cloud-starter-zookeeper-discovery'
         compile 'org.springframework.cloud:spring-cloud-starter-sleuth'
+        compile 'io.reactivex:rxjava'
 
         testCompile 'org.codehaus.groovy:groovy-all'
         testCompile "org.spockframework:spock-core"


### PR DESCRIPTION
 Adding rxjava as a dependency to not fail if someone didn't have it imported in his project