### PR TITLE
More tolerance on: - non-null payload - missing uriSpec

### DIFF
--- a/micro-deps/micro-deps-spring-config/src/main/java/com/ofg/infrastructure/discovery/ServiceDiscoveryInfrastructureConfiguration.java
+++ b/micro-deps/micro-deps-spring-config/src/main/java/com/ofg/infrastructure/discovery/ServiceDiscoveryInfrastructureConfiguration.java
@@ -21,6 +21,8 @@ import org.springframework.context.annotation.*;
 
 import static java.lang.invoke.MethodHandles.lookup;
 
+import java.util.Map;
+
 /**
  * Class holding configuration to Zookeeper server, Zookeeper service instance and to Curator framework.
  * <p/>
@@ -89,7 +91,7 @@ public class ServiceDiscoveryInfrastructureConfiguration {
 
     @Bean
     public InstanceSerializer instanceSerializer() {
-        return new IgnorePayloadInstanceSerializer(Void.class);
+        return new IgnorePayloadInstanceSerializer(Map.class);
     }
 
     @Bean(destroyMethod = "close")
@@ -99,8 +101,8 @@ public class ServiceDiscoveryInfrastructureConfiguration {
                                              ServiceConfigurationResolver serviceConfigurationResolver,
                                              InstanceSerializer instanceSerializer) {
         log.info("Registering myself: " + String.valueOf(serviceInstance));
-        final ServiceDiscovery<Void> serviceDiscovery = ServiceDiscoveryBuilder
-                .builder(Void.class)
+        final ServiceDiscovery<Map> serviceDiscovery = ServiceDiscoveryBuilder
+                .builder(Map.class)
                 .basePath("/" + serviceConfigurationResolver.getBasePath())
                 .client(curatorFramework)
                 .thisInstance(serviceInstance)
@@ -110,7 +112,7 @@ public class ServiceDiscoveryInfrastructureConfiguration {
         return serviceDiscovery;
     }
 
-    private void asyncRegisterInsideZookeeper(final ServiceDiscovery<Void> serviceDiscovery) {
+    private void asyncRegisterInsideZookeeper(final ServiceDiscovery<Map> serviceDiscovery) {
         new Thread(new Runnable() {
             @Override
             public void run() {

--- a/micro-deps/micro-deps-spring-config/src/test/groovy/com/ofg/infrastructure/discovery/ServiceResolverSpec.groovy
+++ b/micro-deps/micro-deps-spring-config/src/test/groovy/com/ofg/infrastructure/discovery/ServiceResolverSpec.groovy
@@ -34,12 +34,12 @@ class ServiceResolverSpec extends Specification {
 
     void setupStubs(ServiceConfigurationResolver serviceConfigurationResolver, CuratorFramework curatorFramework) {
         serviceConfigurationResolver.dependencies.each {
-            ServiceInstance<Void> serviceInstance = ServiceInstance.builder().uriSpec(new UriSpec("{scheme}://{address}:{port}/${it.servicePath.path}"))
+            ServiceInstance<Map> serviceInstance = ServiceInstance.builder().uriSpec(new UriSpec("{scheme}://{address}:{port}/${it.servicePath.path}"))
                     .address('localhost')
                     .port(8030)
                     .name(it.serviceAlias.name)
                     .build()
-            ServiceDiscoveryBuilder.builder(Void).basePath(serviceConfigurationResolver.basePath).client(curatorFramework).thisInstance(serviceInstance).build().start()
+            ServiceDiscoveryBuilder.builder(Map).basePath(serviceConfigurationResolver.basePath).client(curatorFramework).thisInstance(serviceInstance).build().start()
         }
     }
 

--- a/micro-deps/micro-deps/src/main/java/com/ofg/infrastructure/discovery/ZookeeperServiceResolver.java
+++ b/micro-deps/micro-deps/src/main/java/com/ofg/infrastructure/discovery/ZookeeperServiceResolver.java
@@ -11,6 +11,7 @@ import org.apache.curator.x.discovery.ProviderStrategy;
 import org.apache.curator.x.discovery.ServiceDiscovery;
 import org.apache.curator.x.discovery.ServiceInstance;
 import org.apache.curator.x.discovery.ServiceProvider;
+import org.apache.curator.x.discovery.UriSpec;
 
 import java.io.IOException;
 import java.net.URI;
@@ -180,7 +181,12 @@ public class ZookeeperServiceResolver implements ServiceResolver {
         if (instance == null) {
             return null;
         }
-        return URI.create(instance.buildUriSpec());
+        String uriSpec = instance.buildUriSpec();
+        if (uriSpec.isEmpty()) {
+            uriSpec = new UriSpec("{scheme}://{address}:{port}").build(instance);
+        }
+
+        return URI.create(uriSpec);
     }
 
     private ServiceProvider providerFor(ServicePath service) {

--- a/micro-deps/micro-deps/src/main/java/com/ofg/infrastructure/discovery/util/MicroDepsService.java
+++ b/micro-deps/micro-deps/src/main/java/com/ofg/infrastructure/discovery/util/MicroDepsService.java
@@ -20,6 +20,7 @@ import org.apache.curator.x.discovery.UriSpec;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.Map;
 
 /**
  * Class that registers microservice in Zookeeper server and enables its discovery using Curator framework.
@@ -64,7 +65,7 @@ public class MicroDepsService {
         } catch (Exception e) {
             Throwables.propagate(e);
         }
-        serviceDiscovery = ServiceDiscoveryBuilder.builder(Void.class).basePath(configurationResolver.getBasePath()).client(curatorFramework).thisInstance(serviceInstance).build();
+        serviceDiscovery = ServiceDiscoveryBuilder.builder(Map.class).basePath(configurationResolver.getBasePath()).client(curatorFramework).thisInstance(serviceInstance).build();
         dependencyWatcher = new DependencyWatcher(configurationResolver.getDependencies(), serviceDiscovery, new DefaultDependencyPresenceOnStartupVerifier());
         serviceResolver = new ZookeeperServiceResolver(configurationResolver, serviceDiscovery, curatorFramework, new ProviderStrategyFactory());
     }

--- a/micro-deps/micro-deps/src/test/groovy/com/ofg/infrastructure/base/SpecWithZookeper.groovy
+++ b/micro-deps/micro-deps/src/test/groovy/com/ofg/infrastructure/base/SpecWithZookeper.groovy
@@ -17,7 +17,7 @@ class SpecWithZookeper extends Specification {
 
     TestingServer server
     ServiceConfigurationResolver serviceConfigurationResolver
-    ServiceInstance<Void> serviceInstance
+    ServiceInstance<Map> serviceInstance
     CuratorFramework curatorFramework
     ServiceDiscovery serviceDiscovery
     

--- a/micro-deps/micro-deps/src/test/groovy/com/ofg/infrastructure/discovery/IgnorePayloadInstanceSerializerSpec.groovy
+++ b/micro-deps/micro-deps/src/test/groovy/com/ofg/infrastructure/discovery/IgnorePayloadInstanceSerializerSpec.groovy
@@ -32,7 +32,7 @@ class IgnorePayloadInstanceSerializerSpec extends Specification {
         given:
             byte[] instanceBytes = instanceBytes(payloadContent)
         when:
-            new IgnorePayloadInstanceSerializer(Void.class).deserialize(instanceBytes)
+            new IgnorePayloadInstanceSerializer(Map.class).deserialize(instanceBytes)
         then:
             noExceptionThrown()
         where:

--- a/stub-runner/stub-runner/src/main/groovy/com/ofg/stub/registry/StubRegistry.groovy
+++ b/stub-runner/stub-runner/src/main/groovy/com/ofg/stub/registry/StubRegistry.groovy
@@ -42,7 +42,7 @@ class StubRegistry {
     @PackageScope
     static ServiceDiscovery serviceDiscoveryFor(StubServer stubServer, CuratorFramework client) {
         ServiceInstance serviceInstance = serviceInstanceOf(stubServer)
-        return ServiceDiscoveryBuilder.builder(Void)
+        return ServiceDiscoveryBuilder.builder(Map)
                 .basePath(stubServer.projectMetadata.context)
                 .client(client)
                 .thisInstance(serviceInstance)

--- a/stub-runner/stub-runner/src/test/groovy/com/ofg/stub/ProjectMetadataResolverSpec.groovy
+++ b/stub-runner/stub-runner/src/test/groovy/com/ofg/stub/ProjectMetadataResolverSpec.groovy
@@ -55,7 +55,7 @@ class ProjectMetadataResolverSpec extends Specification {
                 .port(COLLABORATOR_URL)
                 .name(TEST_SERVICE_PATH)
                 .build()
-        return ServiceDiscoveryBuilder.builder(Void)
+        return ServiceDiscoveryBuilder.builder(Map)
                 .basePath('pl')
                 .client(curatorFramework)
                 .thisInstance(serviceInstance)


### PR DESCRIPTION
Map-based instead of Void-based serialization to allow parsing non-null payloads.
Handles null uriSpec with a sensible default (into a @Deprecated implementation though), please review if still relevant