### PR TITLE
randomize port when server.port is set to 0

### DIFF
--- a/micro-deps/micro-deps-spring-config/src/main/java/com/ofg/infrastructure/discovery/ZookeeperServiceResolverConfiguration.java
+++ b/micro-deps/micro-deps-spring-config/src/main/java/com/ofg/infrastructure/discovery/ZookeeperServiceResolverConfiguration.java
@@ -66,7 +66,7 @@ public class ZookeeperServiceResolverConfiguration {
 
     private Integer randomizePortIfRequired(String port) {
         Integer portToPick = Integer.valueOf(port);
-        if (portToPick == -1) {
+        if (portToPick <= 0) {
             return SocketUtils.findAvailableTcpPort();
         }
         return portToPick;


### PR DESCRIPTION
When using
@SpringBootTest(webEnvironment = RANDOM_PORT)
server.port is set to 0
which ends up with 
IllegalStateException("Cannot create instance whose port is not greater than 0")
when creating ZookeeperServiceDiscovery bean