### PR TITLE
fix for spring-cloud to microservice.json converter not using stubs

### DIFF
--- a/micro-deps/build.gradle
+++ b/micro-deps/build.gradle
@@ -73,6 +73,8 @@ project(':micro-deps-root:micro-deps-spring-config') {
         testCompile "org.springframework:spring-webmvc"
         testCompile "com.jayway.restassured:rest-assured"
         testCompile 'org.slf4j:slf4j-api'
+        testCompile 'cglib:cglib-nodep'
+        testCompile 'org.objenesis:objenesis'
     }
 }
 

--- a/micro-deps/micro-deps-spring-config/src/main/java/com/ofg/infrastructure/discovery/SpringCloudToMicroserviceJsonConverter.java
+++ b/micro-deps/micro-deps-spring-config/src/main/java/com/ofg/infrastructure/discovery/SpringCloudToMicroserviceJsonConverter.java
@@ -33,7 +33,13 @@ public class SpringCloudToMicroserviceJsonConverter {
                     LoadBalancerType.fromName(zookeeperDependency.getLoadBalancerType().name()),
                     zookeeperDependency.getContentTypeTemplate(),
                     zookeeperDependency.getVersion(),
-                    convertFromMapOfCollection(zookeeperDependency.getHeaders())
+                    convertFromMapOfCollection(zookeeperDependency.getHeaders()),
+                    zookeeperDependency.getStubsConfiguration() == null
+                            ? null
+                            : new MicroserviceConfiguration.Dependency.StubsConfiguration(
+                            zookeeperDependency.getStubsConfiguration().getStubsGroupId(),
+                            zookeeperDependency.getStubsConfiguration().getStubsArtifactId(),
+                            zookeeperDependency.getStubsConfiguration().getStubsClassifier())
             );
             dependencies.add(dependency);
         }

--- a/micro-deps/micro-deps-spring-config/src/test/groovy/com/ofg/infrastructure/discovery/SpringCloudToMicroserviceJsonConverterSpec.groovy
+++ b/micro-deps/micro-deps-spring-config/src/test/groovy/com/ofg/infrastructure/discovery/SpringCloudToMicroserviceJsonConverterSpec.groovy
@@ -9,18 +9,24 @@ import spock.lang.Specification
 
 class SpringCloudToMicroserviceJsonConverterSpec extends Specification {
 
+    ZookeeperDiscoveryProperties discoveryProperties
+
+    String dependencyPath
+
+    def setup() {
+        dependencyPath = 'pl/any/service'
+        discoveryProperties = Stub(ZookeeperDiscoveryProperties)
+        discoveryProperties.root >> dependencyPath
+    }
+
     def "should create collaborator with default stubs"() {
         given:
         ZookeeperDependencies dependencies = new ZookeeperDependencies()
-        String dependencyPath = 'pl/any/service'
-        ZookeeperDiscoveryProperties discoveryProperties = Stub(ZookeeperDiscoveryProperties)
-        discoveryProperties.root >> dependencyPath
         ZookeeperDependency dependency = new ZookeeperDependency(dependencyPath)
         dependencies.setDependencies(['service': dependency])
         SpringCloudToMicroserviceJsonConverter converter = new SpringCloudToMicroserviceJsonConverter("base", dependencies, discoveryProperties)
 
         when:
-        println converter.toMicroserviceJsonNotation()
         def dependenciesMicroserviceJson = new JsonSlurper().parseText(converter.toMicroserviceJsonNotation())
 
         then:
@@ -45,9 +51,6 @@ class SpringCloudToMicroserviceJsonConverterSpec extends Specification {
     def "should convert dependency with defined stubs"() {
         given:
         ZookeeperDependencies dependencies = new ZookeeperDependencies()
-        String dependencyPath = 'pl/any/service'
-        ZookeeperDiscoveryProperties discoveryProperties = Stub(ZookeeperDiscoveryProperties)
-        discoveryProperties.root >> dependencyPath
         ZookeeperDependency dependency = new ZookeeperDependency(dependencyPath)
         String stubPath = 'com.different:service:stub'
         dependency.stubs = stubPath

--- a/micro-deps/micro-deps-spring-config/src/test/groovy/com/ofg/infrastructure/discovery/SpringCloudToMicroserviceJsonConverterSpec.groovy
+++ b/micro-deps/micro-deps-spring-config/src/test/groovy/com/ofg/infrastructure/discovery/SpringCloudToMicroserviceJsonConverterSpec.groovy
@@ -1,0 +1,80 @@
+package com.ofg.infrastructure.discovery
+
+import groovy.json.JsonSlurper
+import org.springframework.cloud.zookeeper.discovery.ZookeeperDiscoveryProperties
+import org.springframework.cloud.zookeeper.discovery.dependency.StubsConfiguration
+import org.springframework.cloud.zookeeper.discovery.dependency.ZookeeperDependencies
+import org.springframework.cloud.zookeeper.discovery.dependency.ZookeeperDependency
+import spock.lang.Specification
+
+class SpringCloudToMicroserviceJsonConverterSpec extends Specification {
+
+    def "should create collaborator with default stubs"() {
+        given:
+        ZookeeperDependencies dependencies = new ZookeeperDependencies()
+        String dependencyPath = 'pl/any/service'
+        ZookeeperDiscoveryProperties discoveryProperties = Stub(ZookeeperDiscoveryProperties)
+        discoveryProperties.root >> dependencyPath
+        ZookeeperDependency dependency = new ZookeeperDependency(dependencyPath)
+        dependencies.setDependencies(['service': dependency])
+        SpringCloudToMicroserviceJsonConverter converter = new SpringCloudToMicroserviceJsonConverter("base", dependencies, discoveryProperties)
+
+        when:
+        println converter.toMicroserviceJsonNotation()
+        def dependenciesMicroserviceJson = new JsonSlurper().parseText(converter.toMicroserviceJsonNotation())
+
+        then:
+        dependenciesMicroserviceJson == [
+                "planyservice": [
+                        "this"        : "base",
+                        "dependencies": [
+                                "service": [
+                                        "path"               : "pl/any/service",
+                                        "stubs"              : "pl.any:service:stubs",
+                                        "load-balancer"      : "ROUND_ROBIN",
+                                        "required"           : false,
+                                        "contentTypeTemplate": "",
+                                        "headers"            : [:],
+                                        "version"            : ""
+                                ]
+                        ]
+                ]
+        ]
+    }
+
+    def "should convert dependency with defined stubs"() {
+        given:
+        ZookeeperDependencies dependencies = new ZookeeperDependencies()
+        String dependencyPath = 'pl/any/service'
+        ZookeeperDiscoveryProperties discoveryProperties = Stub(ZookeeperDiscoveryProperties)
+        discoveryProperties.root >> dependencyPath
+        ZookeeperDependency dependency = new ZookeeperDependency(dependencyPath)
+        String stubPath = 'com.different:service:stub'
+        dependency.stubs = stubPath
+        dependency.stubsConfiguration = new StubsConfiguration(stubPath)
+        dependencies.setDependencies(['service': dependency])
+        SpringCloudToMicroserviceJsonConverter converter = new SpringCloudToMicroserviceJsonConverter("base", dependencies, discoveryProperties)
+
+        when:
+        def dependenciesMicroserviceJson = new JsonSlurper().parseText(converter.toMicroserviceJsonNotation())
+
+        then:
+        dependenciesMicroserviceJson == [
+                "planyservice": [
+                        "this"        : "base",
+                        "dependencies": [
+                                "service": [
+                                        "path"               : "pl/any/service",
+                                        "stubs"              : "com.different:service:stub",
+                                        "load-balancer"      : "ROUND_ROBIN",
+                                        "required"           : false,
+                                        "contentTypeTemplate": "",
+                                        "headers"            : [:],
+                                        "version"            : ""
+                                ]
+                        ]
+                ]
+        ]
+    }
+
+}


### PR DESCRIPTION
Currently spring cloud allows for definition of custom stubs, but microservice.json converter doesn't take advantage of this functionality. Instead it builds stubs from servicePath.

This causes (among other issues) the standalone stub-runner to retrieve erroneous stub paths if custom stubs are defined.