### PR TITLE
bugfix for logging obfuscated response

### DIFF
--- a/micro-infra-spring-base/src/main/groovy/com/ofg/infrastructure/web/logging/feign/FeignRequestResponseLoggingConifguration.java
+++ b/micro-infra-spring-base/src/main/groovy/com/ofg/infrastructure/web/logging/feign/FeignRequestResponseLoggingConifguration.java
@@ -4,13 +4,12 @@ import com.ofg.infrastructure.tracing.EnableTracing;
 import com.ofg.infrastructure.web.logging.FeignCallObfuscatingLogger;
 import com.ofg.infrastructure.web.logging.RequestDataProvider;
 import com.ofg.infrastructure.web.logging.RequestResponseLogger;
-import com.ofg.infrastructure.web.logging.SpanIdProvider;
+import com.ofg.infrastructure.web.logging.RequestIdProvider;
 import feign.Logger;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.AutoConfigureAfter;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.cloud.sleuth.SpanAccessor;
-import org.springframework.cloud.sleuth.Tracer;
 import org.springframework.cloud.sleuth.autoconfig.TraceAutoConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -22,17 +21,17 @@ import org.springframework.context.annotation.Configuration;
 public class FeignRequestResponseLoggingConifguration {
 
     @Bean
-    public SpanIdProvider traceIdProvider(SpanAccessor spanAccessor) {
-        return new SleuthSpanIdProvider(spanAccessor);
+    public RequestIdProvider traceIdProvider(SpanAccessor spanAccessor) {
+        return new SleuthRequestIdProvider(spanAccessor);
     }
     
     @Bean
-    public Logger feignLogger(RequestDataProvider requestDataProvider, SpanIdProvider traceIdProvider, RequestResponseLogger requestResponseLogger) {
+    public Logger feignLogger(RequestDataProvider requestDataProvider, RequestIdProvider traceIdProvider, RequestResponseLogger requestResponseLogger) {
         return new FeignCallObfuscatingLogger(requestDataProvider, traceIdProvider, requestResponseLogger);
     }
     
     @Bean
-    public RequestDataProvider requestDataProvider(@Value("${rest.client.feign.logging.payload.expirationTimeout:5000}") int requestDataExpirationTimeout) {
+    public RequestDataProvider requestDataProvider(@Value("${rest.client.feign.logging.payload.expirationTimeout:20000}") int requestDataExpirationTimeout) {
         return new RequestDataProvider(requestDataExpirationTimeout);
     }
 }

--- a/micro-infra-spring-base/src/main/groovy/com/ofg/infrastructure/web/logging/feign/SleuthRequestIdProvider.java
+++ b/micro-infra-spring-base/src/main/groovy/com/ofg/infrastructure/web/logging/feign/SleuthRequestIdProvider.java
@@ -1,19 +1,19 @@
 package com.ofg.infrastructure.web.logging.feign;
 
 
-import com.ofg.infrastructure.web.logging.SpanIdProvider;
+import com.ofg.infrastructure.web.logging.RequestIdProvider;
 import org.springframework.cloud.sleuth.SpanAccessor;
 
-public class SleuthSpanIdProvider implements SpanIdProvider {
+public class SleuthRequestIdProvider implements RequestIdProvider {
     
     private final SpanAccessor spanAccessor;
 
-    public SleuthSpanIdProvider(SpanAccessor spanAccessor) {
+    public SleuthRequestIdProvider(SpanAccessor spanAccessor) {
         this.spanAccessor = spanAccessor;
     }
 
     @Override
-    public String getSpanId() {
+    public String getRequestId() {
         return String.valueOf(spanAccessor.getCurrentSpan().getSpanId());
     }
 }

--- a/micro-infra-spring-base/src/main/java/com/ofg/infrastructure/web/logging/FeignCallObfuscatingLogger.java
+++ b/micro-infra-spring-base/src/main/java/com/ofg/infrastructure/web/logging/FeignCallObfuscatingLogger.java
@@ -2,6 +2,8 @@ package com.ofg.infrastructure.web.logging;
 
 import feign.Request;
 import feign.Response;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 
@@ -9,34 +11,45 @@ import static com.ofg.infrastructure.web.logging.HttpDataFactory.createHttpData;
 
 public class FeignCallObfuscatingLogger extends feign.Logger.JavaLogger {
 
-    public static final String TAG = "CLIENT";
+    private static final String TAG = "CLIENT";
+    private static final Logger log = LoggerFactory.getLogger(RequestResponseLogger.class);
+
     private final RequestDataProvider requestDataProvider;
-    private final SpanIdProvider traceIdProvider;
+    private final RequestIdProvider requestIdProvider;
     private final RequestResponseLogger requestResponseLogger;
-    
-    public FeignCallObfuscatingLogger(RequestDataProvider requestDataProvider, SpanIdProvider traceIdProvider, RequestResponseLogger requestResponseLogger) {
+
+    public FeignCallObfuscatingLogger(RequestDataProvider requestDataProvider, RequestIdProvider requestIdProvider, RequestResponseLogger requestResponseLogger) {
         this.requestDataProvider = requestDataProvider;
-        this.traceIdProvider = traceIdProvider;
+        this.requestIdProvider = requestIdProvider;
         this.requestResponseLogger = requestResponseLogger;
     }
 
     @Override
     protected void logRequest(String configKey, feign.Logger.Level logLevel, Request request) {
         HttpData reqData = createHttpData(request);
-        String traceId = traceIdProvider.getSpanId();
-        requestDataProvider.store(traceId, reqData);
+        String requestId = requestIdProvider.getRequestId();
+        requestDataProvider.store(requestId, reqData);
         requestResponseLogger.logObfuscatedRequest(reqData, TAG);
         super.logRequest(configKey, logLevel, request);
     }
 
     @Override
     protected Response logAndRebufferResponse(String configKey, feign.Logger.Level logLevel, Response response, long elapsedTime) throws IOException {
-        String traceId = traceIdProvider.getSpanId();
-        HttpData reqData = requestDataProvider.retrieve(traceId);
-        HttpData resData = createHttpData(response);
-        Response rebufferedResponse = Response.create(response.status(), response.reason(), response.headers(), resData.getContent().getBytes());
-        requestResponseLogger.logObfuscatedResponse(reqData, resData, TAG);
-        requestDataProvider.remove(traceId);
-        return super.logAndRebufferResponse(configKey, logLevel, rebufferedResponse, elapsedTime);
+        String requestId = requestIdProvider.getRequestId();
+        HttpData reqData = requestDataProvider.retrieve(requestId);
+        if (requestTraceable(reqData)) {
+            HttpData resData = createHttpData(response);
+            Response rebufferedResponse = Response.create(response.status(), response.reason(), response.headers(), resData.getContent().getBytes());
+            requestResponseLogger.logObfuscatedResponse(reqData, resData, TAG);
+            requestDataProvider.remove(requestId);
+            return super.logAndRebufferResponse(configKey, logLevel, rebufferedResponse, elapsedTime);
+        } else {
+            log.debug("Cannot obfuscate response, matching request data lost");
+            return super.logAndRebufferResponse(configKey, logLevel, response, elapsedTime);
+        }
+    }
+
+    private boolean requestTraceable(HttpData reqData) {
+        return reqData != null;
     }
 }

--- a/micro-infra-spring-base/src/main/java/com/ofg/infrastructure/web/logging/RequestDataProvider.java
+++ b/micro-infra-spring-base/src/main/java/com/ofg/infrastructure/web/logging/RequestDataProvider.java
@@ -14,18 +14,18 @@ public class RequestDataProvider {
         storage = CacheBuilder.newBuilder().expireAfterWrite(timeToLiveMillis, MILLISECONDS).build();
     }
 
-    public void store(String traceId, HttpData data) {
-        Preconditions.checkNotNull(traceId, "traceId cannot be null");
-        Preconditions.checkArgument(!traceId.isEmpty(), "traceId cannot be empty");
-        storage.put(traceId, data);
+    public void store(String requestId, HttpData data) {
+        Preconditions.checkNotNull(requestId, "requestId cannot be null");
+        Preconditions.checkArgument(!requestId.isEmpty(), "requestId cannot be empty");
+        storage.put(requestId, data);
     }
     
-    public HttpData retrieve(String traceId) {
-        return storage.getIfPresent(traceId);
+    public HttpData retrieve(String requestId) {
+        return storage.getIfPresent(requestId);
     }
 
-    public void remove(String traceId) {
-        storage.invalidate(traceId);
+    public void remove(String requestId) {
+        storage.invalidate(requestId);
     }
     
     public long size() {

--- a/micro-infra-spring-base/src/main/java/com/ofg/infrastructure/web/logging/RequestIdProvider.java
+++ b/micro-infra-spring-base/src/main/java/com/ofg/infrastructure/web/logging/RequestIdProvider.java
@@ -1,0 +1,5 @@
+package com.ofg.infrastructure.web.logging;
+
+public interface RequestIdProvider {
+    String getRequestId();
+}

--- a/micro-infra-spring-base/src/main/java/com/ofg/infrastructure/web/logging/SpanIdProvider.java
+++ b/micro-infra-spring-base/src/main/java/com/ofg/infrastructure/web/logging/SpanIdProvider.java
@@ -1,5 +1,0 @@
-package com.ofg.infrastructure.web.logging;
-
-public interface SpanIdProvider {
-    String getSpanId();
-}


### PR DESCRIPTION
when attempting to obfuscate response log, if response cannot be matched to its originating request, logging is skipped