### PR TITLE
Weakening subs repository layout restrictions

### DIFF
--- a/stub-runner/stub-runner/src/main/groovy/com/ofg/stub/mapping/StubRepository.groovy
+++ b/stub-runner/stub-runner/src/main/groovy/com/ofg/stub/mapping/StubRepository.groovy
@@ -1,16 +1,22 @@
 package com.ofg.stub.mapping
 
 import groovy.transform.CompileStatic
-import groovy.transform.PackageScope
 
 @CompileStatic
 class StubRepository {
-    @PackageScope static final String DEFAULT_DESCRIPTORS_DIRECTORY = 'mappings'
+    static final String DEFAULT_DESCRIPTORS_DIRECTORY = 'mappings'
 
     private final DescriptorRepository descriptorRepository
 
     StubRepository(File repositoryRoot) {
         File descriptorDirectory = new File(repositoryRoot, DEFAULT_DESCRIPTORS_DIRECTORY)
+        if (!descriptorDirectory.exists()) {
+            repositoryRoot.eachDirRecurse {
+                if (it.name == DEFAULT_DESCRIPTORS_DIRECTORY) {
+                    descriptorDirectory = it
+                }
+            }
+        }
         descriptorRepository = new DescriptorRepository(descriptorDirectory)
     }
 

--- a/stub-runner/stub-runner/src/test/groovy/com/ofg/stub/mapping/StubRepositorySpec.groovy
+++ b/stub-runner/stub-runner/src/test/groovy/com/ofg/stub/mapping/StubRepositorySpec.groovy
@@ -5,23 +5,31 @@ import spock.lang.Specification
 import static com.ofg.stub.mapping.MappingDescriptor.MappingType.REALM_SPECIFIC
 
 class StubRepositorySpec extends Specification {
-    public static final File REPOSITORY_LOCATION = new File('src/test/resources/repository')
-    public static final File MAPPINGS_REPOSITORY_LOCATION = new File("$REPOSITORY_LOCATION/mappings")
-    public static final MappingDescriptor MAIN_BYE_STUB_DESCRIPTOR = new MappingDescriptor(new File(MAPPINGS_REPOSITORY_LOCATION, 'com/ofg/bye/bye.json'))
-    public static final MappingDescriptor ADMIN_STUB_DESCRIPTOR = new MappingDescriptor(new File(MAPPINGS_REPOSITORY_LOCATION, 'com/ofg/bye/admin/admin.json'))
-    public static final MappingDescriptor PL_BYE_STUB_DESCRIPTOR = new MappingDescriptor(new File(MAPPINGS_REPOSITORY_LOCATION, 'pl/com/ofg/bye/pl_bye.json'), REALM_SPECIFIC)
-    public static final MappingDescriptor PL_OVERRIDDEN_BYE_STUB_DESCRIPTOR = new MappingDescriptor(new File(MAPPINGS_REPOSITORY_LOCATION, 'pl/com/ofg/bye/pl_overridden_bye.json'), REALM_SPECIFIC)
 
     def 'should retrieve all descriptors for given project (both from main and realm specific contexts)'() {
         given:
-            StubRepository repository = new StubRepository(REPOSITORY_LOCATION)
+            StubRepository repository = new StubRepository(new File(repositoryLocation))
             ProjectMetadata projectMetadata = new ProjectMetadata('bye', 'com/ofg/bye', 'pl')
-            List<MappingDescriptor> expectedDescriptors = [MAIN_BYE_STUB_DESCRIPTOR, ADMIN_STUB_DESCRIPTOR , PL_BYE_STUB_DESCRIPTOR, PL_OVERRIDDEN_BYE_STUB_DESCRIPTOR]
+
+            File mappingsRepositoryLocation = new File(repositoryLocation, descriptorMappingsSubPath)
+            MappingDescriptor mainByeStubDescriptor = new MappingDescriptor(new File(mappingsRepositoryLocation, 'com/ofg/bye/bye.json'))
+            MappingDescriptor adminStubDescriptor = new MappingDescriptor(new File(mappingsRepositoryLocation, 'com/ofg/bye/admin/admin.json'))
+            MappingDescriptor plByeStubDescriptor = new MappingDescriptor(new File(mappingsRepositoryLocation, 'pl/com/ofg/bye/pl_bye.json'), REALM_SPECIFIC)
+            MappingDescriptor plOverriddenByeStubDescriptor = new MappingDescriptor(new File(mappingsRepositoryLocation, 'pl/com/ofg/bye/pl_overridden_bye.json'), REALM_SPECIFIC)
+
+            List<MappingDescriptor> expectedDescriptors = [mainByeStubDescriptor, adminStubDescriptor, plByeStubDescriptor, plOverriddenByeStubDescriptor]
+
         when:
             List<MappingDescriptor> descriptors = repository.getProjectDescriptors(projectMetadata)
+
         then:
             descriptors.size() == expectedDescriptors.size()
             descriptors.containsAll(expectedDescriptors)
+
+        where:
+            repositoryLocation                            | descriptorMappingsSubPath
+            'src/test/resources/repository'               | 'mappings'
+            'src/test/resources/deepenMappingsRepository' | 'deeper/located/mappings'
     }
 
     def 'should return empty list if files are missing'() {
@@ -33,4 +41,5 @@ class StubRepositorySpec extends Specification {
         then:
             descriptors.empty
     }
+
 }

--- a/stub-runner/stub-runner/src/test/resources/deepenMappingsRepository/deeper/located/mappings/com/ofg/bye/admin/admin.json
+++ b/stub-runner/stub-runner/src/test/resources/deepenMappingsRepository/deeper/located/mappings/com/ofg/bye/admin/admin.json
@@ -1,0 +1,9 @@
+{
+    "request": {
+        "method": "GET",
+        "url": "/admin"
+    },
+    "response": {
+        "status": 401
+    }
+}

--- a/stub-runner/stub-runner/src/test/resources/deepenMappingsRepository/deeper/located/mappings/com/ofg/bye/bye.json
+++ b/stub-runner/stub-runner/src/test/resources/deepenMappingsRepository/deeper/located/mappings/com/ofg/bye/bye.json
@@ -1,0 +1,13 @@
+{
+    "request": {
+        "method": "GET",
+        "url": "/bye"
+    },
+    "response": {
+        "status": 200,
+        "body": "Goodbye world!",
+        "headers": {
+            "Content-Type": "text/plain"
+        }
+    }
+}

--- a/stub-runner/stub-runner/src/test/resources/deepenMappingsRepository/deeper/located/mappings/com/ofg/ping/ping.json
+++ b/stub-runner/stub-runner/src/test/resources/deepenMappingsRepository/deeper/located/mappings/com/ofg/ping/ping.json
@@ -1,0 +1,13 @@
+{
+    "request": {
+        "method": "GET",
+        "url": "/ping"
+    },
+    "response": {
+        "status": 200,
+        "body": "pong",
+        "headers": {
+            "Content-Type": "text/plain"
+        }
+    }
+}

--- a/stub-runner/stub-runner/src/test/resources/deepenMappingsRepository/deeper/located/mappings/pl/com/ofg/bye/pl_bye.json
+++ b/stub-runner/stub-runner/src/test/resources/deepenMappingsRepository/deeper/located/mappings/pl/com/ofg/bye/pl_bye.json
@@ -1,0 +1,13 @@
+{
+    "request": {
+        "method": "GET",
+        "url": "/pl/bye"
+    },
+    "response": {
+        "status": 200,
+        "body": "pl-bye",
+        "headers": {
+            "Content-Type": "text/plain"
+        }
+    }
+}

--- a/stub-runner/stub-runner/src/test/resources/deepenMappingsRepository/deeper/located/mappings/pl/com/ofg/bye/pl_overridden_bye.json
+++ b/stub-runner/stub-runner/src/test/resources/deepenMappingsRepository/deeper/located/mappings/pl/com/ofg/bye/pl_overridden_bye.json
@@ -1,0 +1,14 @@
+{
+
+    "request": {
+        "method": "GET",
+        "url": "/bye"
+    },
+    "response": {
+        "status": 200,
+        "body": "overridden-bye",
+        "headers": {
+            "Content-Type": "text/plain"
+        }
+    }
+}


### PR DESCRIPTION
Having mapping folder located directly under repositoryRoot can cause that stubs aren't found.
This happens when using SpringCloudContractVerifier instead of Accurest.
Change that affects stubs resolution: https://github.com/spring-cloud/spring-cloud-contract/issues/54