### PR TITLE
Improve caching in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,14 @@ script:
 after_success:
 - ./gradlew jacocoRootReport coveralls -Pcoverage --continue
 
+before_cache:
+  - rm -f  $HOME/.gradle/caches/modules-2/modules-2.lock
+  - rm -fr $HOME/.gradle/caches/*/plugin-resolution/
+  - rm -fr $HOME/.gradle/caches/*/scripts/
+  - rm -fr $HOME/.gradle/caches/*/scripts-remapped/
+  - rm -fr $HOME/.gradle/caches/*/fileHashes/
+  - rm -fr $HOME/.gradle/caches/transforms-1/transforms-1.lock
+
 cache:
   directories:
   - $HOME/.gradle


### PR DESCRIPTION
Should not rebuild after every build.

In 2.14 not all entries are needed, but after upgrade to 3.x they will be useful.