### PR TITLE
configurable logging or ServiceRestClient error responses

### DIFF
--- a/micro-infra-spring-base/src/main/groovy/com/ofg/infrastructure/web/resttemplate/custom/RestTemplate.groovy
+++ b/micro-infra-spring-base/src/main/groovy/com/ofg/infrastructure/web/resttemplate/custom/RestTemplate.groovy
@@ -37,12 +37,12 @@ class RestTemplate extends org.springframework.web.client.RestTemplate {
     }
 
     RestTemplate(int maxLogResponseChars) {
-        this(maxLogResponseChars, null)
+        this(maxLogResponseChars, Optional.empty())
     }
 
-    RestTemplate(int maxLogResponseChars, String errorMessageLogging) {
+    RestTemplate(int maxLogResponseChars, Optional<String> errorMessageLoggingLevel) {
         this.maxLogResponseChars = maxLogResponseChars
-        errorHandler = new ResponseRethrowingErrorHandler(errorMessageLogging)
+        errorHandler = new ResponseRethrowingErrorHandler(errorMessageLoggingLevel)
         requestFactory = new BufferingClientHttpRequestFactory(new SimpleClientHttpRequestFactory())
     }
 

--- a/micro-infra-spring-base/src/main/groovy/com/ofg/infrastructure/web/resttemplate/custom/RestTemplate.groovy
+++ b/micro-infra-spring-base/src/main/groovy/com/ofg/infrastructure/web/resttemplate/custom/RestTemplate.groovy
@@ -8,6 +8,7 @@ import org.springframework.http.client.SimpleClientHttpRequestFactory
 import org.springframework.web.client.ResponseExtractor
 
 import java.lang.reflect.Type
+
 /**
  * Default implementation of RestTemplate {@see RestTemplate} with custom
  * <ul>
@@ -36,8 +37,12 @@ class RestTemplate extends org.springframework.web.client.RestTemplate {
     }
 
     RestTemplate(int maxLogResponseChars) {
+        this(maxLogResponseChars, null)
+    }
+
+    RestTemplate(int maxLogResponseChars, String errorMessageLogging) {
         this.maxLogResponseChars = maxLogResponseChars
-        errorHandler = new ResponseRethrowingErrorHandler()
+        errorHandler = new ResponseRethrowingErrorHandler(errorMessageLogging)
         requestFactory = new BufferingClientHttpRequestFactory(new SimpleClientHttpRequestFactory())
     }
 

--- a/micro-infra-spring-base/src/main/groovy/com/ofg/infrastructure/web/resttemplate/fluent/ServiceRestClientConfigurationSupport.groovy
+++ b/micro-infra-spring-base/src/main/groovy/com/ofg/infrastructure/web/resttemplate/fluent/ServiceRestClientConfigurationSupport.groovy
@@ -50,8 +50,8 @@ class ServiceRestClientConfigurationSupport {
     @Value('${rest.client.maxLogResponseChars:4096}')
     int maxLogResponseChars
 
-    @Value('${rest.client.responseErrorMessageLogging:ERROR}')
-    String responseErrorMessageLogging
+    @Value('${rest.client.responseErrorMessageLoggingLevel:ERROR}')
+    String responseErrorMessageLoggingLevel
 
     @Autowired(required = false)
     List<ClientHttpRequestInterceptor> interceptors
@@ -95,7 +95,7 @@ class ServiceRestClientConfigurationSupport {
     @Bean
     RestOperations microInfraSpringRestTemplate() {
         RestClientConfigurer configurer = getRestClientConfigurer()
-        RestTemplate restTemplate = new RestTemplate(configurer.maxLogResponseChars, responseErrorMessageLogging)
+        RestTemplate restTemplate = new RestTemplate(configurer.maxLogResponseChars, Optional.of(responseErrorMessageLoggingLevel))
         this.configureMessageConverters(restTemplate.messageConverters)
         restTemplate.requestFactory = requestFactory()
         restTemplate.interceptors = filteredInterceptors()

--- a/micro-infra-spring-base/src/main/groovy/com/ofg/infrastructure/web/resttemplate/fluent/ServiceRestClientConfigurationSupport.groovy
+++ b/micro-infra-spring-base/src/main/groovy/com/ofg/infrastructure/web/resttemplate/fluent/ServiceRestClientConfigurationSupport.groovy
@@ -7,7 +7,6 @@ import com.ofg.infrastructure.discovery.MicroserviceConfigurationNotPresentExcep
 import com.ofg.infrastructure.discovery.ServiceConfigurationResolver
 import com.ofg.infrastructure.discovery.ServiceResolver
 import com.ofg.infrastructure.web.resttemplate.RestOperationsMetricsAspect
-import com.ofg.infrastructure.web.resttemplate.custom.ResponseRethrowingErrorHandler
 import com.ofg.infrastructure.web.resttemplate.custom.RestTemplate
 import com.ofg.infrastructure.web.resttemplate.fluent.config.RestClientConfigurer
 import groovy.transform.CompileStatic
@@ -51,7 +50,7 @@ class ServiceRestClientConfigurationSupport {
     @Value('${rest.client.maxLogResponseChars:4096}')
     int maxLogResponseChars
 
-    @Value('{rest.client.responseErrorMessageLogging:ERROR}')
+    @Value('${rest.client.responseErrorMessageLogging:ERROR}')
     String responseErrorMessageLogging
 
     @Autowired(required = false)

--- a/micro-infra-spring-base/src/main/groovy/com/ofg/infrastructure/web/resttemplate/fluent/ServiceRestClientConfigurationSupport.groovy
+++ b/micro-infra-spring-base/src/main/groovy/com/ofg/infrastructure/web/resttemplate/fluent/ServiceRestClientConfigurationSupport.groovy
@@ -7,12 +7,12 @@ import com.ofg.infrastructure.discovery.MicroserviceConfigurationNotPresentExcep
 import com.ofg.infrastructure.discovery.ServiceConfigurationResolver
 import com.ofg.infrastructure.discovery.ServiceResolver
 import com.ofg.infrastructure.web.resttemplate.RestOperationsMetricsAspect
+import com.ofg.infrastructure.web.resttemplate.custom.ResponseRethrowingErrorHandler
 import com.ofg.infrastructure.web.resttemplate.custom.RestTemplate
 import com.ofg.infrastructure.web.resttemplate.fluent.config.RestClientConfigurer
 import groovy.transform.CompileStatic
 import groovy.util.logging.Slf4j
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
@@ -51,6 +51,8 @@ class ServiceRestClientConfigurationSupport {
     @Value('${rest.client.maxLogResponseChars:4096}')
     int maxLogResponseChars
 
+    @Value('{rest.client.responseErrorMessageLogging:ERROR}')
+    String responseErrorMessageLogging
 
     @Autowired(required = false)
     List<ClientHttpRequestInterceptor> interceptors
@@ -94,7 +96,7 @@ class ServiceRestClientConfigurationSupport {
     @Bean
     RestOperations microInfraSpringRestTemplate() {
         RestClientConfigurer configurer = getRestClientConfigurer()
-        RestTemplate restTemplate = new RestTemplate(configurer.maxLogResponseChars)
+        RestTemplate restTemplate = new RestTemplate(configurer.maxLogResponseChars, responseErrorMessageLogging)
         this.configureMessageConverters(restTemplate.messageConverters)
         restTemplate.requestFactory = requestFactory()
         restTemplate.interceptors = filteredInterceptors()


### PR DESCRIPTION
Reasoning for this change is two-fold:
1. in many situations, when using ServiceRestClient in catch clause usually first thing to do is log exception on error message - which in most cases just doubles the error message that was already logged by default ResponseRethrowingErrorHandler
2. there are situations where receiving 4xx response is expected behaviour - in that case logging error message result in confusion, since developer seeing error message in logs might assumes that something broke

Not wanting to change the default behaviour of this handler I think it's best to make it configurable and let the developers decide.