### PR TITLE
Fix for CONFIG_FOLDER property tests when set in environment

### DIFF
--- a/micro-infra-spring-config/build.gradle
+++ b/micro-infra-spring-config/build.gradle
@@ -26,6 +26,7 @@ dependencies {
     testRuntime "ch.qos.logback:logback-classic"
     testCompile "com.jayway.awaitility:awaitility"
     testCompile "com.jayway.awaitility:awaitility-groovy"
+    testCompile 'com.github.stefanbirkner:system-rules:1.16.0'
 }
 
 test {

--- a/micro-infra-spring-config/src/test/groovy/com/ofg/infrastructure/property/LogbackConfigurationSpec.groovy
+++ b/micro-infra-spring-config/src/test/groovy/com/ofg/infrastructure/property/LogbackConfigurationSpec.groovy
@@ -1,13 +1,26 @@
 package com.ofg.infrastructure.property
 
+import org.junit.Rule
+import org.junit.contrib.java.lang.system.EnvironmentVariables
 import spock.lang.Specification
+import spock.lang.Subject
 import spock.util.environment.RestoreSystemProperties
 
 import static com.ofg.infrastructure.property.AppCoordinates.CONFIG_FOLDER
 
+@RestoreSystemProperties
 class LogbackConfigurationSpec extends Specification {
 
+    @Rule
+    EnvironmentVariables environmentVariables = new EnvironmentVariables()
+
+    @Subject
     LogbackConfiguration config = new LogbackConfiguration()
+
+    def setup() {
+        environmentVariables.set(CONFIG_FOLDER, null)
+        System.clearProperty(CONFIG_FOLDER)
+    }
 
     def 'log pattern should contain correlationId'() {
         expect:
@@ -34,7 +47,6 @@ class LogbackConfigurationSpec extends Specification {
             config.getRollingMaxHistory() > 0
     }
 
-    @RestoreSystemProperties
     def 'should read logger configuration from global.properties file'() {
         given:
             System.setProperty(CONFIG_FOLDER, getConfigFolder())

--- a/micro-infra-spring-config/src/test/groovy/com/ofg/infrastructure/property/PropertiesFolderFinderSpec.groovy
+++ b/micro-infra-spring-config/src/test/groovy/com/ofg/infrastructure/property/PropertiesFolderFinderSpec.groovy
@@ -1,21 +1,33 @@
 package com.ofg.infrastructure.property
 
+import org.junit.Rule
+import org.junit.contrib.java.lang.system.EnvironmentVariables
 import spock.lang.Specification
+import spock.lang.Subject
 import spock.util.environment.RestoreSystemProperties
 
 import static com.ofg.infrastructure.property.AppCoordinates.CONFIG_FOLDER
 import static com.ofg.infrastructure.property.PropertiesFolderFinder.DEFAULT_CONFIG_DIR
 
+@RestoreSystemProperties
 class PropertiesFolderFinderSpec extends Specification {
 
+    @Rule
+    EnvironmentVariables environmentVariables = new EnvironmentVariables()
+
+    @Subject
     PropertiesFolderFinder propertiesFolderFinder = new PropertiesFolderFinder()
+
+    def setup() {
+        environmentVariables.set(CONFIG_FOLDER, null)
+        System.clearProperty(CONFIG_FOLDER)
+    }
 
     def 'should return default config folder when CONFIG_FOLDER is not set'() {
         expect:
             propertiesFolderFinder.find() == DEFAULT_CONFIG_DIR
     }
 
-    @RestoreSystemProperties
     def 'should return config folder from CONFIG_FOLDER variable'() {
         given:
             System.setProperty(CONFIG_FOLDER, 'properties')


### PR DESCRIPTION
When `CONFIG_FOLDER` property is set in the system (for example in `~/.bashrc`) or passed via `-D` some tests are failing. Few of them silently assumed that this property is not set.