### PR TITLE
Bumping WireMock to 2.13.0 Standalone

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -122,7 +122,7 @@ configure(srcSubprojects) {
 
             //test
             dependency 'io.rest-assured:rest-assured:3.0.6'
-            dependency 'com.github.tomakehurst:wiremock:2.12.0'
+            dependency 'com.github.tomakehurst:wiremock-standalone:2.13.0'
             dependency 'cglib:cglib-nodep:3.2.5'
             dependency 'org.objenesis:objenesis:2.6'
             dependency 'com.github.stefanbirkner:system-rules:1.17.0'

--- a/micro-deps/build.gradle
+++ b/micro-deps/build.gradle
@@ -94,7 +94,7 @@ project(':micro-deps-root:micro-deps-spring-test-config') {
         compile 'org.spockframework:spock-spring'
         compile 'org.springframework:spring-webmvc'
         compile 'org.springframework:spring-test'
-        compile 'com.github.tomakehurst:wiremock'
+        compile 'com.github.tomakehurst:wiremock-standalone'
         compile 'javax.servlet:javax.servlet-api:3.1.0'
 
         testCompile 'io.rest-assured:rest-assured'

--- a/stub-runner/stub-runner/build.gradle
+++ b/stub-runner/stub-runner/build.gradle
@@ -8,9 +8,7 @@ dependencies {
     compile project(':micro-deps-root:micro-deps')
     compile 'org.apache.ivy:ivy:2.4.0'
     compile 'org.codehaus.groovy:groovy-all'
-    compile 'com.github.tomakehurst:wiremock'
-    compile 'org.eclipse.jetty:jetty-servlet'
-    compile 'org.eclipse.jetty:jetty-servlets'
+    compile 'com.github.tomakehurst:wiremock-standalone'
     compile 'javax.servlet:javax.servlet-api:3.1.0'
     compile 'org.apache.curator:curator-x-discovery'
     compile 'org.apache.curator:curator-test'


### PR DESCRIPTION
SpringBoot 1.5.x plugin automatically applies dependency-management plugin which imports BOM `org.springframework.boot:spring-boot-dependencies`.

This forces WireMock to use resolved Jetty version which is 9.4.x (see [jetty.version](https://search.maven.org/remotecontent?filepath=org/springframework/boot/spring-boot-dependencies/1.5.9.RELEASE/spring-boot-dependencies-1.5.9.RELEASE.pom)), but WireMock is not ready for that. It supports Jetty 9.2.x.

Tom Akehurst suggests to use `wiremock-standalone` artifact which contains Jetty with appropriate version inside. See https://github.com/tomakehurst/wiremock/issues/644 and https://github.com/tomakehurst/wiremock/issues/551.