### PR TITLE
Spring Cloud Edgware.SR2 + others

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -103,7 +103,7 @@ configure(srcSubprojects) {
 
     dependencyManagement {
         imports {
-            mavenBom 'org.springframework.cloud:spring-cloud-starter-parent:Edgware.SR1'
+            mavenBom 'org.springframework.cloud:spring-cloud-starter-parent:Edgware.SR2'
         }
 
         dependencies {
@@ -121,11 +121,11 @@ configure(srcSubprojects) {
             }
 
             //test
-            dependency 'io.rest-assured:rest-assured:3.0.6'
-            dependency 'com.github.tomakehurst:wiremock-standalone:2.13.0'
-            dependency 'cglib:cglib-nodep:3.2.5'
+            dependency 'io.rest-assured:rest-assured:3.0.7'
+            dependency 'com.github.tomakehurst:wiremock-standalone:2.15.0'
+            dependency 'cglib:cglib-nodep:3.2.6'
             dependency 'org.objenesis:objenesis:2.6'
-            dependency 'com.github.stefanbirkner:system-rules:1.17.0'
+            dependency 'com.github.stefanbirkner:system-rules:1.17.1'
 
             dependencySet(group: 'ch.qos.logback', version: '1.2.3') {
                 entry 'logback-core'
@@ -174,7 +174,7 @@ configure(srcSubprojects) {
         groovyClasspath = project.configurations.jansi
     }
     dependencies {
-        jansi 'org.fusesource.jansi:jansi:1.16'
+        jansi 'org.fusesource.jansi:jansi:1.17'
     }
 }
 


### PR DESCRIPTION
Bumping versions:
* Spring Cloud Edgware.SR2
* CGLib 3.2.6
* RestAssured 3.0.7
* Wiremock 2.15.0
* SystemRules 1.17.1
* Jansi 1.17